### PR TITLE
fix(memory): align auto-capture scope with consolidation

### DIFF
--- a/src/hooks/memory-decision-detection/hook.test.ts
+++ b/src/hooks/memory-decision-detection/hook.test.ts
@@ -58,7 +58,27 @@ describe("memory-decision-detection hook", () => {
       expect(storage.goldenRules).toHaveLength(1)
       expect(storage.goldenRules[0].rule).toBe("Preference: Let's use TypeScript")
       expect(storage.goldenRules[0].confidence).toBe(0.8)
-      expect(storage.goldenRules[0].domain).toBe("session")
+      expect(storage.goldenRules[0].domain).toBe("project")
+    })
+  })
+
+  describe("#given custom memory scope is global", () => {
+    test("captures golden rule in the configured scope", async () => {
+      //#given
+      const hook = createMemoryDecisionDetectionHook({ storage, scope: "global" })
+
+      //#when
+      await hook["chat.message"](
+        { sessionID: "ses_scope" },
+        {
+          message: { role: "user" },
+          parts: [{ type: "text", text: "let's use TypeScript" }],
+        }
+      )
+
+      //#then
+      expect(storage.goldenRules).toHaveLength(1)
+      expect(storage.goldenRules[0].domain).toBe("global")
     })
   })
 

--- a/src/hooks/memory-decision-detection/hook.ts
+++ b/src/hooks/memory-decision-detection/hook.ts
@@ -1,13 +1,14 @@
 import type { AutoCaptureConfig } from "@/config/schema/memory"
 import { subagentSessions } from "@/features/claude-code-session-state"
 import { filterContent } from "@/features/memory/privacy-filter"
-import type { IMemoryStorage } from "@/features/memory/types"
+import type { IMemoryStorage, MemoryScope } from "@/features/memory/types"
 import { log } from "@/shared/logger"
 
 export interface MemoryDecisionDetectionDeps {
   storage: IMemoryStorage
   autoCapture?: AutoCaptureConfig
   privacyTags?: string[]
+  scope?: MemoryScope
 }
 
 type HookInput = {
@@ -88,6 +89,7 @@ function computeHash(sessionID: string, summary: string): string {
 export function createMemoryDecisionDetectionHook(deps: MemoryDecisionDetectionDeps) {
   const seenHashes = new Set<string>()
   const privacyTags = deps.privacyTags ?? []
+  const scope = deps.scope ?? "project"
 
   return {
     "chat.message": async (input: HookInput, output: HookOutput): Promise<void> => {
@@ -113,7 +115,7 @@ export function createMemoryDecisionDetectionHook(deps: MemoryDecisionDetectionD
         await deps.storage.addGoldenRule({
           id: crypto.randomUUID(),
           rule: filteredSummary,
-          domain: "session",
+          domain: scope,
           confidence: 0.8,
           times_validated: 0,
           times_violated: 0,

--- a/src/hooks/memory-integration/integration.test.ts
+++ b/src/hooks/memory-integration/integration.test.ts
@@ -121,6 +121,7 @@ function createAutoCaptureSystem(args: {
         storage: args.storage,
         autoCapture: args.autoCapture,
         privacyTags: args.privacyTags,
+        scope: args.scope,
       })
 
   const flushHook = disabledHooks.has("memory-pre-compaction-flush")
@@ -188,6 +189,7 @@ describe("memory auto-capture integration", () => {
         expect(storage.goldenRules).toHaveLength(1)
         expect(storage.learnings[0].domain).toBe("project")
         expect(storage.goldenRules[0].rule).toBe("Preference: Let's use Bun")
+        expect(storage.goldenRules[0].domain).toBe("project")
       })
     })
   })

--- a/src/hooks/memory-integration/integration.test.ts
+++ b/src/hooks/memory-integration/integration.test.ts
@@ -99,6 +99,7 @@ function createLifecycleSpies() {
 function createAutoCaptureSystem(args: {
   storage: IMemoryStorage
   autoCapture: AutoCaptureConfig
+  scope?: MemoryScope
   privacyTags?: string[]
   disabledHooks?: HookName[]
   onIdle: () => Promise<void>
@@ -111,6 +112,7 @@ function createAutoCaptureSystem(args: {
         storage: args.storage,
         autoCapture: args.autoCapture,
         privacyTags: args.privacyTags,
+        scope: args.scope,
       })
 
   const decisionHook = disabledHooks.has("memory-decision-detection")
@@ -184,6 +186,7 @@ describe("memory auto-capture integration", () => {
         //#then
         expect(storage.learnings).toHaveLength(1)
         expect(storage.goldenRules).toHaveLength(1)
+        expect(storage.learnings[0].domain).toBe("project")
         expect(storage.goldenRules[0].rule).toBe("Preference: Let's use Bun")
       })
     })

--- a/src/hooks/memory-learning/hook.test.ts
+++ b/src/hooks/memory-learning/hook.test.ts
@@ -12,6 +12,9 @@ function createMockStorage(): IMemoryStorage & { learnings: Learning[] } {
     async getLearning(id: string) {
       return learnings.find((l) => l.id === id) ?? null
     },
+    async getLearningsByScope(_scope) {
+      return learnings
+    },
     async updateLearning(id: string, updates: Partial<Learning>) {
       const idx = learnings.findIndex((l) => l.id === id)
       if (idx >= 0) {
@@ -26,6 +29,10 @@ function createMockStorage(): IMemoryStorage & { learnings: Learning[] } {
     async getGoldenRules() {
       return []
     },
+    async getGoldenRulesByScope(_scope) {
+      return []
+    },
+    async deleteGoldenRule(_id: string) {},
     async getStats() {
       return { learnings: learnings.length, goldenRules: 0 }
     },
@@ -57,7 +64,28 @@ describe("memory-learning hook", () => {
       expect(storage.learnings).toHaveLength(1)
       expect(storage.learnings[0].type).toBe("failure")
       expect(storage.learnings[0].tool_name).toBe("Bash")
+      expect(storage.learnings[0].domain).toBe("project")
       expect(storage.learnings[0].summary).toContain("Bash")
+    })
+  })
+
+  describe("#given custom memory scope is global", () => {
+    test("captures learning in the configured scope", async () => {
+      //#given
+      const hook = createMemoryLearningHook({ storage, scope: "global" })
+      const input = { tool: "Bash", sessionID: "ses_scope", callID: "call_scope" }
+      const output = {
+        title: "command failed",
+        output: "Error: module not found",
+        metadata: {} as Record<string, unknown>,
+      }
+
+      //#when
+      await hook["tool.execute.after"](input, output)
+
+      //#then
+      expect(storage.learnings).toHaveLength(1)
+      expect(storage.learnings[0].domain).toBe("global")
     })
   })
 

--- a/src/hooks/memory-learning/hook.test.ts
+++ b/src/hooks/memory-learning/hook.test.ts
@@ -355,6 +355,26 @@ describe("memory-learning hook", () => {
       expect(storage.learnings[0].context_hash.length).toBe(64)
     })
 
+    test("isolates context_hash by scope", async () => {
+      //#given
+      const projectHook = createMemoryLearningHook({ storage, scope: "project" })
+      const globalHook = createMemoryLearningHook({ storage, scope: "global" })
+      const input = { tool: "Bash", sessionID: "ses_hash_scope", callID: "call_hash_scope" }
+      const output = {
+        title: "failed",
+        output: "Error: permission denied on /etc/shadow",
+        metadata: {} as Record<string, unknown>,
+      }
+
+      //#when
+      await projectHook["tool.execute.after"](input, output)
+      await globalHook["tool.execute.after"]({ ...input, callID: "call_hash_scope_2" }, output)
+
+      //#then
+      expect(storage.learnings).toHaveLength(2)
+      expect(storage.learnings[0].context_hash).not.toBe(storage.learnings[1].context_hash)
+    })
+
     test("generates summary from tool name and first line of output", async () => {
       //#given
       const hook = createMemoryLearningHook({ storage })

--- a/src/hooks/memory-learning/hook.ts
+++ b/src/hooks/memory-learning/hook.ts
@@ -1,4 +1,4 @@
-import type { IMemoryStorage, Learning, LearningType } from "@/features/memory/types"
+import type { IMemoryStorage, Learning, LearningType, MemoryScope } from "@/features/memory/types"
 import type { AutoCaptureConfig } from "@/config/schema/memory"
 import { filterContent, shouldSkipTool } from "@/features/memory/privacy-filter"
 import { log } from "@/shared/logger"
@@ -8,6 +8,7 @@ export interface MemoryLearningDeps {
   storage: IMemoryStorage
   privacyTags?: string[]
   autoCapture?: AutoCaptureConfig
+  scope?: MemoryScope
 }
 
 type HookInput = { tool: string; sessionID: string; callID: string }
@@ -119,6 +120,7 @@ function computeHash(tool: string, sessionID: string, summary: string): string {
 export function createMemoryLearningHook(deps: MemoryLearningDeps) {
   const seenHashes = new Set<string>()
   const privacyTags = deps.privacyTags ?? []
+  const scope = deps.scope ?? "project"
 
   return {
     "tool.execute.after": async (input: HookInput, output: HookOutput): Promise<void> => {
@@ -140,7 +142,7 @@ export function createMemoryLearningHook(deps: MemoryLearningDeps) {
         summary,
         context: filteredContext,
         tool_name: input.tool,
-        domain: "tool-execution",
+        domain: scope,
         tags: [input.tool.toLowerCase()],
         utility_score: 0.5,
         times_consulted: 0,

--- a/src/hooks/memory-learning/hook.ts
+++ b/src/hooks/memory-learning/hook.ts
@@ -111,9 +111,9 @@ function buildSummary(tool: string, output: string): string {
   return `${tool}: ${firstLine.slice(0, 100)}`
 }
 
-function computeHash(tool: string, sessionID: string, summary: string): string {
+function computeHash(tool: string, sessionID: string, scope: string, summary: string): string {
   const hasher = new Bun.CryptoHasher("sha256")
-  hasher.update(`${tool}:${sessionID}:${summary.slice(0, 100)}`)
+  hasher.update(`${tool}:${sessionID}:${scope}:${summary.slice(0, 100)}`)
   return hasher.digest("hex")
 }
 
@@ -128,7 +128,7 @@ export function createMemoryLearningHook(deps: MemoryLearningDeps) {
       if (!shouldCapture(input.tool, output, deps.autoCapture)) return
 
       const summary = buildSummary(input.tool, output!.output)
-      const contextHash = computeHash(input.tool, input.sessionID, summary)
+      const contextHash = computeHash(input.tool, input.sessionID, scope, summary)
 
       if (seenHashes.has(contextHash)) return
       seenHashes.add(contextHash)

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -214,6 +214,7 @@ export function createSessionHooks(args: {
             storage: manager.storage,
             autoCapture: pluginConfig.memory?.auto_capture,
             privacyTags: pluginConfig.memory?.privacy_tags,
+            scope: pluginConfig.memory?.scope ?? "project",
           })
         } catch (error) {
           log(`Failed to initialize memory-learning hook: ${error instanceof Error ? error.message : String(error)}`)

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -232,6 +232,7 @@ export function createSessionHooks(args: {
             storage: manager.storage,
             autoCapture: pluginConfig.memory?.auto_capture,
             privacyTags: pluginConfig.memory?.privacy_tags,
+            scope: pluginConfig.memory?.scope ?? "project",
           })
         } catch (error) {
           log(`Failed to initialize memory-decision-detection hook: ${error instanceof Error ? error.message : String(error)}`)


### PR DESCRIPTION
## Summary
- align memory-learning captures with the configured memory scope instead of writing to an orphaned pseudo-domain
- align memory-decision-detection captures with the configured memory scope so consolidation reads the same bucket runtime hooks write
- add hook and integration coverage proving project/global scope values now flow through auto-capture

## Testing
- bun test src/hooks/memory-learning/hook.test.ts src/hooks/memory-decision-detection/hook.test.ts src/hooks/memory-integration/integration.test.ts src/features/memory/consolidation/consolidator.test.ts
- bun run typecheck

Closes #19