### PR TITLE
fix(memory): record consult and access signals for promotion

### DIFF
--- a/src/features/memory/__tests__/integration.test.ts
+++ b/src/features/memory/__tests__/integration.test.ts
@@ -341,6 +341,8 @@ describe("Memory lifecycle integration", () => {
           const elfTool = createElfTool({ storage, search, db, filterContent, computeContextHash, findExistingByHash })
           const searchResult = JSON.parse((await elfTool.execute({ action: "search", query: "elf search target" }, {} as Parameters<typeof elfTool.execute>[1])) as string) as { results: unknown[] }
           expect(searchResult.results.length).toBeGreaterThanOrEqual(1)
+          const searchedId = (searchResult.results[0] as { id: string }).id
+          expect((await storage.getLearning(searchedId))?.times_consulted).toBe(1)
 
           const addRuleResult = JSON.parse((await elfTool.execute({ action: "add-rule", content: "Always validate memory scope before consolidation", type: "golden_rule", scope: "project" }, {} as Parameters<typeof elfTool.execute>[1])) as string) as { status: string }
           expect(addRuleResult.status).toBe("added")

--- a/src/features/memory/__tests__/integration.test.ts
+++ b/src/features/memory/__tests__/integration.test.ts
@@ -158,6 +158,11 @@ describe("Memory lifecycle integration", () => {
             search,
             collector: { register(_id, payload) { registered.push({ source: payload.source, content: payload.content }) } },
             getUsage: () => ({ usedTokens: 100, remainingTokens: 900, usagePercentage: 0.1 }),
+            recordLearningConsulted: async (learning) => {
+              await storage.updateLearning(learning.id, {
+                times_consulted: learning.times_consulted + 1,
+              })
+            },
           })
           const preInjectionResults = await search.searchAll("bash", {
             maxResults: 5,
@@ -172,6 +177,7 @@ describe("Memory lifecycle integration", () => {
           )
           expect(registered[0]?.source).toBe("memory")
           expect(registered[0]?.content).toContain("## Agent Memory")
+          expect((await storage.getLearning(targetId))?.times_consulted).toBe(2)
 
           await batchUpdateScores([{ memoryId: targetId, outcome: "used" }], storage)
           expect((await storage.getLearning(targetId))?.utility_score).toBeCloseTo(0.01, 6)

--- a/src/features/memory/scoring/utility-scorer.test.ts
+++ b/src/features/memory/scoring/utility-scorer.test.ts
@@ -120,9 +120,13 @@ describe("#given batchUpdateScores", () => {
           updateLearning: mock(() => Promise.resolve()),
           addLearning: mock(() => Promise.resolve()),
           getLearning: mock(() => Promise.resolve(null)),
+          getLearningsByScope: mock(() => Promise.resolve([])),
+          incrementTimesConsulted: mock(() => Promise.resolve()),
           deleteLearning: mock(() => Promise.resolve()),
           addGoldenRule: mock(() => Promise.resolve()),
           getGoldenRules: mock(() => Promise.resolve([])),
+          getGoldenRulesByScope: mock(() => Promise.resolve([])),
+          deleteGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 
@@ -140,9 +144,13 @@ describe("#given batchUpdateScores", () => {
           updateLearning: mock(() => Promise.resolve()),
           addLearning: mock(() => Promise.resolve()),
           getLearning: mock(() => Promise.resolve(null)),
+          getLearningsByScope: mock(() => Promise.resolve([])),
+          incrementTimesConsulted: mock(() => Promise.resolve()),
           deleteLearning: mock(() => Promise.resolve()),
           addGoldenRule: mock(() => Promise.resolve()),
           getGoldenRules: mock(() => Promise.resolve([])),
+          getGoldenRulesByScope: mock(() => Promise.resolve([])),
+          deleteGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 
@@ -160,9 +168,13 @@ describe("#given batchUpdateScores", () => {
           updateLearning: mock(() => Promise.resolve()),
           addLearning: mock(() => Promise.resolve()),
           getLearning: mock(() => Promise.resolve(null)),
+          getLearningsByScope: mock(() => Promise.resolve([])),
+          incrementTimesConsulted: mock(() => Promise.resolve()),
           deleteLearning: mock(() => Promise.resolve()),
           addGoldenRule: mock(() => Promise.resolve()),
           getGoldenRules: mock(() => Promise.resolve([])),
+          getGoldenRulesByScope: mock(() => Promise.resolve([])),
+          deleteGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 
@@ -182,9 +194,13 @@ describe("#given batchUpdateScores", () => {
           updateLearning: mock(() => Promise.resolve()),
           addLearning: mock(() => Promise.resolve()),
           getLearning: mock(() => Promise.resolve(null)),
+          getLearningsByScope: mock(() => Promise.resolve([])),
+          incrementTimesConsulted: mock(() => Promise.resolve()),
           deleteLearning: mock(() => Promise.resolve()),
           addGoldenRule: mock(() => Promise.resolve()),
           getGoldenRules: mock(() => Promise.resolve([])),
+          getGoldenRulesByScope: mock(() => Promise.resolve([])),
+          deleteGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 

--- a/src/features/memory/storage/memory-storage.ts
+++ b/src/features/memory/storage/memory-storage.ts
@@ -100,6 +100,17 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
     ).run(existing.rowid, merged.summary, merged.context, payload.tags ?? "", merged.tool_name, merged.domain)
   })
 
+  const incrementTimesConsultedTx = db.transaction((id: string) => {
+    const now = new Date().toISOString()
+    const result = db.prepare(
+      "UPDATE learnings SET times_consulted = times_consulted + 1, updated_at = ? WHERE id = ?"
+    ).run(now, id)
+
+    if (result.changes === 0) {
+      throw new Error(`Learning not found: ${id}`)
+    }
+  })
+
   const deleteLearningTx = db.transaction((id: string) => {
     const row = db.prepare("SELECT rowid FROM learnings WHERE id = ?").get(id) as { rowid: number } | null
     if (row) db.prepare("DELETE FROM learnings_fts WHERE rowid = ?").run(row.rowid)
@@ -142,6 +153,9 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
     },
     async updateLearning(id, updates) {
       updateLearningTx(id, updates)
+    },
+    async incrementTimesConsulted(id) {
+      incrementTimesConsultedTx(id)
     },
     async deleteLearning(id) {
       deleteLearningTx(id)

--- a/src/features/memory/types.test.ts
+++ b/src/features/memory/types.test.ts
@@ -128,10 +128,14 @@ describe("Memory System Types", () => {
         const storage: IMemoryStorage = {
           addLearning: async () => {},
           getLearning: async () => null,
+          getLearningsByScope: async () => [],
+          incrementTimesConsulted: async () => {},
           updateLearning: async () => {},
           deleteLearning: async () => {},
           addGoldenRule: async () => {},
           getGoldenRules: async () => [],
+          getGoldenRulesByScope: async () => [],
+          deleteGoldenRule: async () => {},
           getStats: async () => ({ learnings: 0, goldenRules: 0 }),
         }
         expect(storage).toBeDefined()
@@ -140,6 +144,7 @@ describe("Memory System Types", () => {
       test("should have IMemorySearch interface with search method", () => {
         const search: IMemorySearch = {
           search: async () => [],
+          searchLearnings: async () => [],
         }
         expect(search).toBeDefined()
       })

--- a/src/features/memory/types.ts
+++ b/src/features/memory/types.ts
@@ -80,6 +80,7 @@ export interface IMemoryStorage {
   addLearning(learning: Learning): Promise<void>
   getLearning(id: string): Promise<Learning | null>
   getLearningsByScope(scope: MemoryScope): Promise<Learning[]>
+  incrementTimesConsulted(id: string): Promise<void>
   updateLearning(id: string, updates: Partial<Learning>): Promise<void>
   deleteLearning(id: string): Promise<void>
   addGoldenRule(rule: GoldenRule): Promise<void>

--- a/src/hooks/memory-decision-detection/hook.test.ts
+++ b/src/hooks/memory-decision-detection/hook.test.ts
@@ -14,6 +14,7 @@ function createMockStorage(): IMemoryStorage & { goldenRules: GoldenRule[] } {
     async getLearningsByScope(_scope) {
       return []
     },
+    async incrementTimesConsulted(_id: string) {},
     async updateLearning(_id: string, _updates: Partial<Learning>) {},
     async deleteLearning(_id: string) {},
     async addGoldenRule(rule: GoldenRule) {

--- a/src/hooks/memory-injection/hook.test.ts
+++ b/src/hooks/memory-injection/hook.test.ts
@@ -301,6 +301,34 @@ describe("createMemoryInjectionHook", () => {
         const estimatedTokens = Math.ceil(content.length / 4)
         expect(estimatedTokens).toBeLessThanOrEqual(500)
       })
+
+      it("#then records consultations only for learnings that remain after trimming", async () => {
+        //#given
+        const longLearning = "A".repeat(2000)
+        const search = createMockSearch({
+          searchGoldenRules: async () => [goldenRuleResult("Short rule")],
+          searchAll: async () => [
+            learningResult(longLearning),
+            learningResult("Short learning"),
+          ],
+        })
+        const hook = createMemoryInjectionHook({
+          search,
+          collector: mockCollector,
+          getUsage: () => ({ usedTokens: 5000, remainingTokens: 15000, usagePercentage: 0.25 }),
+          recordLearningConsulted: consultTracker.record,
+          config: { maxTokens: 500 },
+        })
+
+        const input = {}
+        const output: TransformOutput = { messages: [msg("user", "test query")] }
+
+        //#when
+        await hook["experimental.chat.messages.transform"](input, output)
+
+        //#then
+        expect(consultTracker.consulted).toHaveLength(0)
+      })
     })
 
     describe("#when golden rules alone exceed goldenRuleMaxTokens (200) in throttled mode", () => {

--- a/src/hooks/memory-injection/hook.test.ts
+++ b/src/hooks/memory-injection/hook.test.ts
@@ -32,6 +32,17 @@ function createMockCollector() {
   }
 }
 
+function createConsultTracker() {
+  const consulted: LearningLike[] = []
+  type LearningLike = { id: string; times_consulted: number; summary: string }
+  return {
+    consulted,
+    async record(learning: LearningLike) {
+      consulted.push(learning)
+    },
+  }
+}
+
 type TransformOutput = { messages: Array<{ info: Record<string, unknown>; parts: Array<{ type: string; text?: string }> }> }
 
 function msg(role: string, text: string, sessionID = "ses-1"): TransformOutput["messages"][number] {
@@ -83,9 +94,11 @@ function learningResult(summary: string, score = 0.6): MemorySearchResult {
 
 describe("createMemoryInjectionHook", () => {
   let mockCollector: ReturnType<typeof createMockCollector>
+  let consultTracker: ReturnType<typeof createConsultTracker>
 
   beforeEach(() => {
     mockCollector = createMockCollector()
+    consultTracker = createConsultTracker()
   })
 
   describe("#given subagent session", () => {
@@ -188,6 +201,7 @@ describe("createMemoryInjectionHook", () => {
           search,
           collector: mockCollector,
           getUsage: () => ({ usedTokens: 5000, remainingTokens: 15000, usagePercentage: 0.25 }),
+          recordLearningConsulted: consultTracker.record,
         })
 
         const input = {}
@@ -203,6 +217,10 @@ describe("createMemoryInjectionHook", () => {
         expect(injected.content).toContain("Always use parameterized queries")
         expect(injected.content).toContain("Relevant Learnings")
         expect(injected.content).toContain("Use bun test for running tests")
+        expect(consultTracker.consulted.map((learning) => learning.summary)).toEqual([
+          "Use bun test for running tests",
+          "Mock modules before importing",
+        ])
       })
     })
 

--- a/src/hooks/memory-injection/hook.ts
+++ b/src/hooks/memory-injection/hook.ts
@@ -40,6 +40,7 @@ export interface MemoryInjectionDeps {
   getUsage?: () => UsageResult | null
   getMainSessionID?: () => string | undefined
   config?: { maxTokens?: number; goldenRuleMaxTokens?: number }
+  recordLearningConsulted?: (learning: Learning) => Promise<void>
 }
 
 type TransformInput = Record<string, unknown>
@@ -85,10 +86,12 @@ export function createMemoryInjectionHook(deps: MemoryInjectionDeps) {
           .map((r) => (r.entry as GoldenRule).rule)
           .filter((rule) => !isLikelyMemoryDump(rule))
 
-        const learnings = allResults
-          .filter((r) => r.type === "learning")
-          .map((r) => (r.entry as Learning).summary)
-          .filter((summary) => !isLikelyMemoryDump(summary))
+        const learningEntries = allResults
+          .filter((r): r is MemorySearchResult & { entry: Learning } => r.type === "learning")
+          .map((r) => r.entry as Learning)
+          .filter((learning) => !isLikelyMemoryDump(learning.summary))
+
+        const learnings = learningEntries.map((learning) => learning.summary)
 
         if (goldenRules.length === 0 && learnings.length === 0) return
 
@@ -101,6 +104,14 @@ export function createMemoryInjectionHook(deps: MemoryInjectionDeps) {
           content: injectionBlock,
           priority: "normal",
         })
+
+        if (deps.recordLearningConsulted) {
+          await Promise.allSettled(
+            learningEntries.map(async (learning) => {
+              await deps.recordLearningConsulted?.(learning)
+            })
+          )
+        }
 
         log("[memory-injection] injected memory context", {
           goldenRules: goldenRules.length,

--- a/src/hooks/memory-injection/hook.ts
+++ b/src/hooks/memory-injection/hook.ts
@@ -87,7 +87,7 @@ export function createMemoryInjectionHook(deps: MemoryInjectionDeps) {
           .filter((rule) => !isLikelyMemoryDump(rule))
 
         const learningEntries = allResults
-          .filter((r): r is MemorySearchResult & { entry: Learning } => r.type === "learning")
+          .filter((r) => r.type === "learning")
           .map((r) => r.entry as Learning)
           .filter((learning) => !isLikelyMemoryDump(learning.summary))
 
@@ -98,6 +98,8 @@ export function createMemoryInjectionHook(deps: MemoryInjectionDeps) {
         const injectionBlock = buildInjectionBlock(goldenRules, learnings, tokenBudget)
         if (!injectionBlock) return
 
+        const injectedLearningEntries = learningEntries.slice(0, learnings.length)
+
         deps.collector.register(sessionID, {
           id: "memory-injection",
           source: "memory",
@@ -106,11 +108,19 @@ export function createMemoryInjectionHook(deps: MemoryInjectionDeps) {
         })
 
         if (deps.recordLearningConsulted) {
-          await Promise.allSettled(
-            learningEntries.map(async (learning) => {
+          const consultResults = await Promise.allSettled(
+            injectedLearningEntries.map(async (learning) => {
               await deps.recordLearningConsulted?.(learning)
             })
           )
+
+          for (const result of consultResults) {
+            if (result.status === "rejected") {
+              log("[memory-injection] failed to record learning consultation", {
+                error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+              })
+            }
+          }
         }
 
         log("[memory-injection] injected memory context", {

--- a/src/hooks/memory-integration/integration.test.ts
+++ b/src/hooks/memory-integration/integration.test.ts
@@ -40,6 +40,10 @@ function createMockStorage(): IMemoryStorage & { learnings: Learning[]; goldenRu
     async getLearningsByScope(_scope: MemoryScope) {
       return learnings
     },
+    async incrementTimesConsulted(id: string) {
+      const learning = learnings.find((entry) => entry.id === id)
+      if (learning) learning.times_consulted += 1
+    },
     async updateLearning(id: string, updates: Partial<Learning>) {
       const index = learnings.findIndex((learning) => learning.id === id)
       if (index < 0) return

--- a/src/hooks/memory-learning/hook.test.ts
+++ b/src/hooks/memory-learning/hook.test.ts
@@ -15,6 +15,10 @@ function createMockStorage(): IMemoryStorage & { learnings: Learning[] } {
     async getLearningsByScope(_scope) {
       return learnings
     },
+    async incrementTimesConsulted(id: string) {
+      const learning = learnings.find((entry) => entry.id === id)
+      if (learning) learning.times_consulted += 1
+    },
     async updateLearning(id: string, updates: Partial<Learning>) {
       const idx = learnings.findIndex((l) => l.id === id)
       if (idx >= 0) {

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -46,7 +46,7 @@ export function createTransformHooks(args: {
 
   const thinkingBlockValidator = hookSlot("thinking-block-validator", () => createThinkingBlockValidatorHook(), isHookEnabled, safeHookEnabled)
 
-  const memoryInjection = hookSlot("memory-injection", () => { try { const { getMemoryManager } = require("../../features/memory/manager"); const manager = getMemoryManager(); return createMemoryInjectionHook({ search: manager.search, collector: contextCollector, getMainSessionID, recordLearningConsulted: async (learning) => { await manager.storage.updateLearning(learning.id, { times_consulted: learning.times_consulted + 1 }) } }) } catch (error) { log(`Failed to initialize memory-injection hook: ${error instanceof Error ? error.message : String(error)}`); return null } }, isHookEnabled, safeHookEnabled)
+  const memoryInjection = hookSlot("memory-injection", () => { try { const { getMemoryManager } = require("../../features/memory/manager"); const manager = getMemoryManager(); return createMemoryInjectionHook({ search: manager.search, collector: contextCollector, getMainSessionID, recordLearningConsulted: async (learning) => { await manager.storage.incrementTimesConsulted(learning.id) } }) } catch (error) { log(`Failed to initialize memory-injection hook: ${error instanceof Error ? error.message : String(error)}`); return null } }, isHookEnabled, safeHookEnabled)
 
   const heartbeatPruner = hookSlot("heartbeat-pruner", () => createHeartbeatPrunerHook(), isHookEnabled, safeHookEnabled)
 

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -46,7 +46,7 @@ export function createTransformHooks(args: {
 
   const thinkingBlockValidator = hookSlot("thinking-block-validator", () => createThinkingBlockValidatorHook(), isHookEnabled, safeHookEnabled)
 
-  const memoryInjection = hookSlot("memory-injection", () => { try { const { getMemoryManager } = require("../../features/memory/manager"); const manager = getMemoryManager(); return createMemoryInjectionHook({ search: manager.search, collector: contextCollector, getMainSessionID }) } catch (error) { log(`Failed to initialize memory-injection hook: ${error instanceof Error ? error.message : String(error)}`); return null } }, isHookEnabled, safeHookEnabled)
+  const memoryInjection = hookSlot("memory-injection", () => { try { const { getMemoryManager } = require("../../features/memory/manager"); const manager = getMemoryManager(); return createMemoryInjectionHook({ search: manager.search, collector: contextCollector, getMainSessionID, recordLearningConsulted: async (learning) => { await manager.storage.updateLearning(learning.id, { times_consulted: learning.times_consulted + 1 }) } }) } catch (error) { log(`Failed to initialize memory-injection hook: ${error instanceof Error ? error.message : String(error)}`); return null } }, isHookEnabled, safeHookEnabled)
 
   const heartbeatPruner = hookSlot("heartbeat-pruner", () => createHeartbeatPrunerHook(), isHookEnabled, safeHookEnabled)
 

--- a/src/tools/elf/tool.test.ts
+++ b/src/tools/elf/tool.test.ts
@@ -64,6 +64,8 @@ describe("#given ELF tool", () => {
         expect(parsed.results).toBeArray()
         expect(parsed.results.length).toBeGreaterThan(0)
         expect(parsed.results[0].score).toBeNumber()
+        const stored = await storage.getLearning(parsed.results[0].id)
+        expect(stored?.times_consulted).toBe(1)
       })
 
       it("returns empty results for unmatched query", async () => {

--- a/src/tools/elf/tool.ts
+++ b/src/tools/elf/tool.ts
@@ -85,6 +85,20 @@ async function handleSearch(deps: ElfToolDeps, args: ElfToolArgs): Promise<strin
     results = await deps.search.searchAll(args.query, options)
   }
 
+  await Promise.allSettled(
+    results
+      .filter((result): result is MemorySearchResult & { entry: LearningType extends never ? never : { id: string; times_consulted: number } } => result.type === "learning")
+      .map(async (result) => {
+        const learning = result.entry as unknown as {
+          id: string
+          times_consulted: number
+        }
+        await deps.storage.updateLearning(learning.id, {
+          times_consulted: learning.times_consulted + 1,
+        })
+      })
+  )
+
   return JSON.stringify({
     results: results.map((r) => ({
       id: (r.entry as { id: string }).id,

--- a/src/tools/elf/tool.ts
+++ b/src/tools/elf/tool.ts
@@ -87,15 +87,10 @@ async function handleSearch(deps: ElfToolDeps, args: ElfToolArgs): Promise<strin
 
   await Promise.allSettled(
     results
-      .filter((result): result is MemorySearchResult & { entry: LearningType extends never ? never : { id: string; times_consulted: number } } => result.type === "learning")
+      .filter((result) => result.type === "learning")
       .map(async (result) => {
-        const learning = result.entry as unknown as {
-          id: string
-          times_consulted: number
-        }
-        await deps.storage.updateLearning(learning.id, {
-          times_consulted: learning.times_consulted + 1,
-        })
+        const learning = result.entry as { id: string }
+        await deps.storage.incrementTimesConsulted(learning.id)
       })
   )
 


### PR DESCRIPTION
## Summary
- record learning consultations when memories are actually injected into prompt context
- record learning consultations for explicit ELF search results instead of treating search as a pure read with no promotion signal
- extend hook and integration coverage so consultation counts now move through both runtime consumption paths

## Testing
- bun test src/hooks/memory-injection/hook.test.ts src/tools/elf/tool.test.ts src/features/memory/__tests__/integration.test.ts
- bun run typecheck

Closes #18