### PR TITLE
fix(memory): wire context-usage data into injection throttling

### DIFF
--- a/src/hooks/context-window-monitor/hook.test.ts
+++ b/src/hooks/context-window-monitor/hook.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 import { createContextWindowMonitorHook } from "./hook"
+import { clearAllSessionTokenUsage, getSessionContextUsage } from "./session-usage-cache"
 
 const ANTHROPIC_CONTEXT_ENV_KEY = "ANTHROPIC_1M_CONTEXT"
 const VERTEX_CONTEXT_ENV_KEY = "VERTEX_ANTHROPIC_1M_CONTEXT"
@@ -39,12 +40,44 @@ describe("context-window-monitor", () => {
 
   beforeEach(() => {
     ctx = createMockCtx()
+    clearAllSessionTokenUsage()
     delete process.env[ANTHROPIC_CONTEXT_ENV_KEY]
     delete process.env[VERTEX_CONTEXT_ENV_KEY]
   })
 
   afterEach(() => {
+    clearAllSessionTokenUsage()
     resetContextLimitEnv()
+  })
+
+  it("should expose cached session usage for other hooks", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never)
+    const sessionID = "ses_usage_cache"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            finish: true,
+            tokens: {
+              input: 150000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    const usage = getSessionContextUsage(sessionID)
+    expect(usage).not.toBeNull()
+    expect(usage?.usedTokens).toBe(160000)
+    expect(usage?.usagePercentage).toBe(0.8)
   })
 
   // #given event caches token info from message.updated

--- a/src/hooks/context-window-monitor/hook.test.ts
+++ b/src/hooks/context-window-monitor/hook.test.ts
@@ -80,6 +80,36 @@ describe("context-window-monitor", () => {
     expect(usage?.usagePercentage).toBe(0.8)
   })
 
+  it("should expose 1M-based usage when model cache enables it", async () => {
+    const hook = createContextWindowMonitorHook(ctx as never, { anthropicContext1MEnabled: true })
+    const sessionID = "ses_usage_cache_1m"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            finish: true,
+            tokens: {
+              input: 150000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    const usage = getSessionContextUsage(sessionID)
+    expect(usage).not.toBeNull()
+    expect(usage?.usedTokens).toBe(160000)
+    expect(usage?.usagePercentage).toBe(0.16)
+  })
+
   // #given event caches token info from message.updated
   // #when tool.execute.after is called
   // #then session.messages() should NOT be called

--- a/src/hooks/context-window-monitor/hook.ts
+++ b/src/hooks/context-window-monitor/hook.ts
@@ -25,10 +25,6 @@ You are using Anthropic Claude with 1M context window.
 You have plenty of context remaining - do NOT rush or skip tasks.
 Complete your work thoroughly and methodically.`
 
-function isAnthropicProvider(providerID: string): boolean {
-  return providerID === "anthropic" || providerID === "google-vertex-anthropic"
-}
-
 export function createContextWindowMonitorHook(
   _ctx: PluginInput,
   modelCacheState?: ModelCacheStateLike,
@@ -86,7 +82,12 @@ export function createContextWindowMonitorHook(
       if (!info || info.role !== "assistant" || !info.finish) return
       if (!info.sessionID || !info.providerID || !info.tokens) return
 
-      cacheSessionTokenUsage(info.sessionID, info.providerID, info.tokens)
+      cacheSessionTokenUsage(
+        info.sessionID,
+        info.providerID,
+        info.tokens,
+        getAnthropicActualLimit(modelCacheState)
+      )
     }
   }
 

--- a/src/hooks/context-window-monitor/hook.ts
+++ b/src/hooks/context-window-monitor/hook.ts
@@ -1,5 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { createSystemDirective, SystemDirectiveTypes } from "@/shared/hook-utils/system-directive"
+import { cacheSessionTokenUsage, clearSessionTokenUsage, getSessionContextUsage } from "./session-usage-cache"
+import type { TokenInfo } from "./session-usage-cache"
 
 const ANTHROPIC_DISPLAY_LIMIT = 1_000_000
 const DEFAULT_ANTHROPIC_ACTUAL_LIMIT = 200_000
@@ -23,18 +25,6 @@ You are using Anthropic Claude with 1M context window.
 You have plenty of context remaining - do NOT rush or skip tasks.
 Complete your work thoroughly and methodically.`
 
-interface TokenInfo {
-  input: number
-  output: number
-  reasoning: number
-  cache: { read: number; write: number }
-}
-
-interface CachedTokenState {
-  providerID: string
-  tokens: TokenInfo
-}
-
 function isAnthropicProvider(providerID: string): boolean {
   return providerID === "anthropic" || providerID === "google-vertex-anthropic"
 }
@@ -44,7 +34,6 @@ export function createContextWindowMonitorHook(
   modelCacheState?: ModelCacheStateLike,
 ) {
   const remindedSessions = new Set<string>()
-  const tokenCache = new Map<string, CachedTokenState>()
 
   const toolExecuteAfter = async (
     input: { tool: string; sessionID: string; callID: string },
@@ -54,25 +43,20 @@ export function createContextWindowMonitorHook(
 
     if (remindedSessions.has(sessionID)) return
 
-    const cached = tokenCache.get(sessionID)
-    if (!cached) return
-
-    if (!isAnthropicProvider(cached.providerID)) return
-
-    const lastTokens = cached.tokens
-    const totalInputTokens = (lastTokens?.input ?? 0) + (lastTokens?.cache?.read ?? 0)
+    const usage = getSessionContextUsage(sessionID)
+    if (!usage) return
 
     const actualUsagePercentage =
-      totalInputTokens / getAnthropicActualLimit(modelCacheState)
+      usage.usedTokens / getAnthropicActualLimit(modelCacheState)
 
     if (actualUsagePercentage < CONTEXT_WARNING_THRESHOLD) return
 
     remindedSessions.add(sessionID)
 
-    const displayUsagePercentage = totalInputTokens / ANTHROPIC_DISPLAY_LIMIT
+    const displayUsagePercentage = usage.usedTokens / ANTHROPIC_DISPLAY_LIMIT
     const usedPct = (displayUsagePercentage * 100).toFixed(1)
     const remainingPct = ((1 - displayUsagePercentage) * 100).toFixed(1)
-    const usedTokens = totalInputTokens.toLocaleString()
+    const usedTokens = usage.usedTokens.toLocaleString()
     const limitTokens = ANTHROPIC_DISPLAY_LIMIT.toLocaleString()
 
     output.output += `\n\n${CONTEXT_REMINDER}
@@ -86,7 +70,7 @@ export function createContextWindowMonitorHook(
       const sessionInfo = props?.info as { id?: string } | undefined
       if (sessionInfo?.id) {
         remindedSessions.delete(sessionInfo.id)
-        tokenCache.delete(sessionInfo.id)
+        clearSessionTokenUsage(sessionInfo.id)
       }
     }
 
@@ -102,10 +86,7 @@ export function createContextWindowMonitorHook(
       if (!info || info.role !== "assistant" || !info.finish) return
       if (!info.sessionID || !info.providerID || !info.tokens) return
 
-      tokenCache.set(info.sessionID, {
-        providerID: info.providerID,
-        tokens: info.tokens,
-      })
+      cacheSessionTokenUsage(info.sessionID, info.providerID, info.tokens)
     }
   }
 

--- a/src/hooks/context-window-monitor/index.ts
+++ b/src/hooks/context-window-monitor/index.ts
@@ -1,1 +1,7 @@
 export { createContextWindowMonitorHook } from "./hook"
+export {
+  cacheSessionTokenUsage,
+  clearAllSessionTokenUsage,
+  clearSessionTokenUsage,
+  getSessionContextUsage,
+} from "./session-usage-cache"

--- a/src/hooks/context-window-monitor/session-usage-cache.ts
+++ b/src/hooks/context-window-monitor/session-usage-cache.ts
@@ -10,6 +10,7 @@ export interface TokenInfo {
 interface CachedTokenState {
   providerID: string
   tokens: TokenInfo
+  actualLimit: number
 }
 
 export interface SessionUsageSnapshot {
@@ -24,15 +25,13 @@ function isAnthropicProvider(providerID: string): boolean {
   return providerID === "anthropic" || providerID === "google-vertex-anthropic"
 }
 
-function getActualLimit(): number {
-  return process.env.ANTHROPIC_1M_CONTEXT === "true" ||
-    process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
-    ? 1_000_000
-    : DEFAULT_ACTUAL_LIMIT
-}
-
-export function cacheSessionTokenUsage(sessionID: string, providerID: string, tokens: TokenInfo): void {
-  tokenCache.set(sessionID, { providerID, tokens })
+export function cacheSessionTokenUsage(
+  sessionID: string,
+  providerID: string,
+  tokens: TokenInfo,
+  actualLimit = DEFAULT_ACTUAL_LIMIT
+): void {
+  tokenCache.set(sessionID, { providerID, tokens, actualLimit })
 }
 
 export function clearSessionTokenUsage(sessionID: string): void {
@@ -45,7 +44,7 @@ export function getSessionContextUsage(sessionID: string): SessionUsageSnapshot 
   if (!isAnthropicProvider(cached.providerID)) return null
 
   const usedTokens = (cached.tokens.input ?? 0) + (cached.tokens.cache?.read ?? 0)
-  const limit = getActualLimit()
+  const limit = cached.actualLimit
   const usagePercentage = limit > 0 ? usedTokens / limit : 0
 
   return {

--- a/src/hooks/context-window-monitor/session-usage-cache.ts
+++ b/src/hooks/context-window-monitor/session-usage-cache.ts
@@ -1,0 +1,60 @@
+const DEFAULT_ACTUAL_LIMIT = 200_000
+
+export interface TokenInfo {
+  input: number
+  output: number
+  reasoning: number
+  cache: { read: number; write: number }
+}
+
+interface CachedTokenState {
+  providerID: string
+  tokens: TokenInfo
+}
+
+export interface SessionUsageSnapshot {
+  usedTokens: number
+  remainingTokens: number
+  usagePercentage: number
+}
+
+const tokenCache = new Map<string, CachedTokenState>()
+
+function isAnthropicProvider(providerID: string): boolean {
+  return providerID === "anthropic" || providerID === "google-vertex-anthropic"
+}
+
+function getActualLimit(): number {
+  return process.env.ANTHROPIC_1M_CONTEXT === "true" ||
+    process.env.VERTEX_ANTHROPIC_1M_CONTEXT === "true"
+    ? 1_000_000
+    : DEFAULT_ACTUAL_LIMIT
+}
+
+export function cacheSessionTokenUsage(sessionID: string, providerID: string, tokens: TokenInfo): void {
+  tokenCache.set(sessionID, { providerID, tokens })
+}
+
+export function clearSessionTokenUsage(sessionID: string): void {
+  tokenCache.delete(sessionID)
+}
+
+export function getSessionContextUsage(sessionID: string): SessionUsageSnapshot | null {
+  const cached = tokenCache.get(sessionID)
+  if (!cached) return null
+  if (!isAnthropicProvider(cached.providerID)) return null
+
+  const usedTokens = (cached.tokens.input ?? 0) + (cached.tokens.cache?.read ?? 0)
+  const limit = getActualLimit()
+  const usagePercentage = limit > 0 ? usedTokens / limit : 0
+
+  return {
+    usedTokens,
+    remainingTokens: Math.max(0, limit - usedTokens),
+    usagePercentage,
+  }
+}
+
+export function clearAllSessionTokenUsage(): void {
+  tokenCache.clear()
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export { createTodoContinuationEnforcer, type TodoContinuationEnforcer } from "./todo-continuation-enforcer";
-export { createContextWindowMonitorHook } from "./context-window-monitor";
+export { createContextWindowMonitorHook, getSessionContextUsage, clearAllSessionTokenUsage } from "./context-window-monitor";
 export { createSessionNotification, sendSessionNotification, playSessionNotificationSound, detectPlatform, getDefaultSoundPath, buildWindowsToastScript, escapeAppleScriptText, escapePowerShellSingleQuotedText, createIdleNotificationScheduler } from "./session-notification";
 export { hasIncompleteTodos } from "./session-todo-status";
 export { createSessionRecoveryHook, type SessionRecoveryHook, type SessionRecoveryOptions } from "./session-recovery";

--- a/src/hooks/memory-injection/hook.test.ts
+++ b/src/hooks/memory-injection/hook.test.ts
@@ -575,4 +575,33 @@ describe("createMemoryInjectionHook", () => {
       })
     })
   })
+
+  describe("#given getUsage needs the resolved sessionID", () => {
+    describe("#when transform runs with a concrete session id", () => {
+      it("#then passes that session id into getUsage", async () => {
+        //#given
+        let capturedSessionID = ""
+        const search = createMockSearch({
+          searchGoldenRules: async () => [goldenRuleResult("Rule")],
+        })
+        const hook = createMemoryInjectionHook({
+          search,
+          collector: mockCollector,
+          getUsage: (sessionID: string) => {
+            capturedSessionID = sessionID
+            return { usedTokens: 1000, remainingTokens: 9000, usagePercentage: 0.1 }
+          },
+        })
+
+        const input = {}
+        const output: TransformOutput = { messages: [msg("user", "hello", "ses-usage")] }
+
+        //#when
+        await hook["experimental.chat.messages.transform"](input, output)
+
+        //#then
+        expect(capturedSessionID).toBe("ses-usage")
+      })
+    })
+  })
 })

--- a/src/hooks/memory-injection/hook.ts
+++ b/src/hooks/memory-injection/hook.ts
@@ -37,7 +37,7 @@ interface UsageResult {
 export interface MemoryInjectionDeps {
   search: MemorySearchService
   collector: CollectorLike
-  getUsage?: () => UsageResult | null
+  getUsage?: (sessionID: string) => UsageResult | null
   getMainSessionID?: () => string | undefined
   config?: { maxTokens?: number; goldenRuleMaxTokens?: number }
   recordLearningConsulted?: (learning: Learning) => Promise<void>
@@ -61,15 +61,15 @@ export function createMemoryInjectionHook(deps: MemoryInjectionDeps) {
         const metadata = (input as Record<string, unknown>).metadata as Record<string, unknown> | undefined
         if (metadata?.isSubagent === true) return
 
-        const usage = deps.getUsage?.() ?? null
+        const messages = output.messages ?? []
+        const sessionID = resolveSessionID(messages, deps.getMainSessionID)
+        if (!sessionID) return
+
+        const usage = deps.getUsage?.(sessionID) ?? null
         if (usage && usage.usagePercentage > SKIP_THRESHOLD) return
 
         const isThrottled = usage !== null && usage.usagePercentage > THROTTLE_THRESHOLD
         const tokenBudget = isThrottled ? goldenRuleMaxTokens : maxTokens
-
-        const messages = output.messages ?? []
-        const sessionID = resolveSessionID(messages, deps.getMainSessionID)
-        if (!sessionID) return
 
         const lastUserMessage = extractLastUserMessage(messages)
         const query = lastUserMessage ?? ""

--- a/src/plugin/hooks/create-transform-hooks.ts
+++ b/src/plugin/hooks/create-transform-hooks.ts
@@ -6,6 +6,7 @@ import {
   createKeywordDetectorHook,
   createThinkingBlockValidatorHook,
   createMemoryInjectionHook,
+  getSessionContextUsage,
   createHeartbeatPrunerHook,
 } from "@/hooks"
 import {
@@ -46,7 +47,7 @@ export function createTransformHooks(args: {
 
   const thinkingBlockValidator = hookSlot("thinking-block-validator", () => createThinkingBlockValidatorHook(), isHookEnabled, safeHookEnabled)
 
-  const memoryInjection = hookSlot("memory-injection", () => { try { const { getMemoryManager } = require("../../features/memory/manager"); const manager = getMemoryManager(); return createMemoryInjectionHook({ search: manager.search, collector: contextCollector, getMainSessionID, recordLearningConsulted: async (learning) => { await manager.storage.incrementTimesConsulted(learning.id) } }) } catch (error) { log(`Failed to initialize memory-injection hook: ${error instanceof Error ? error.message : String(error)}`); return null } }, isHookEnabled, safeHookEnabled)
+  const memoryInjection = hookSlot("memory-injection", () => { try { const { getMemoryManager } = require("../../features/memory/manager"); const manager = getMemoryManager(); return createMemoryInjectionHook({ search: manager.search, collector: contextCollector, getMainSessionID, getUsage: getSessionContextUsage, recordLearningConsulted: async (learning) => { await manager.storage.incrementTimesConsulted(learning.id) } }) } catch (error) { log(`Failed to initialize memory-injection hook: ${error instanceof Error ? error.message : String(error)}`); return null } }, isHookEnabled, safeHookEnabled)
 
   const heartbeatPruner = hookSlot("heartbeat-pruner", () => createHeartbeatPrunerHook(), isHookEnabled, safeHookEnabled)
 


### PR DESCRIPTION
## Summary
- cache per-session token usage from the existing context-window-monitor event path so other hooks can read real context pressure
- wire that cached usage into memory-injection through transform-hook setup instead of leaving getUsage undefined
- keep throttling logic session-aware by resolving usage with the same session id used for injection

## Testing
- bun test src/hooks/context-window-monitor/hook.test.ts src/hooks/memory-injection/hook.test.ts
- bun run typecheck

Closes #20