### PR TITLE
fix(memory): return real add-rule IDs and correct golden-rule dedup

### DIFF
--- a/src/features/memory/storage/memory-storage.test.ts
+++ b/src/features/memory/storage/memory-storage.test.ts
@@ -37,8 +37,7 @@ describe("#given memory storage", () => {
           .get("Use bun:test for unit tests") as { id: string } | null
 
         expect(row).not.toBeNull()
-        expect(row?.id).not.toBe("caller-provided-id")
-        expect(row?.id).toMatch(/^[0-9a-f-]{36}$/)
+        expect(row?.id).toBe("caller-provided-id")
 
         const learning = await storage.getLearning(row!.id)
         expect(learning?.summary).toBe("Use bun:test for unit tests")
@@ -126,7 +125,7 @@ describe("#given memory storage", () => {
     describe("#then", () => {
       it("filters golden rules by domain and reports counts", async () => {
         await storage.addGoldenRule({
-          id: "ignored",
+          id: "testing-rule-id",
           rule: "Prefer deterministic tests",
           domain: "testing",
           confidence: 0.9,
@@ -137,7 +136,7 @@ describe("#given memory storage", () => {
           updated_at: "",
         })
         await storage.addGoldenRule({
-          id: "ignored",
+          id: "database-rule-id",
           rule: "Batch database writes in transactions",
           domain: "database",
           confidence: 0.8,

--- a/src/features/memory/storage/memory-storage.ts
+++ b/src/features/memory/storage/memory-storage.ts
@@ -134,7 +134,12 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
   return {
     async addLearning(learning) {
       const now = new Date().toISOString()
-      addLearningTx({ ...learning, id: crypto.randomUUID(), created_at: now, updated_at: now })
+      addLearningTx({
+        ...learning,
+        id: learning.id || crypto.randomUUID(),
+        created_at: learning.created_at || now,
+        updated_at: learning.updated_at || now,
+      })
     },
     async getLearning(id) {
       const row = db.prepare("SELECT rowid, * FROM learnings WHERE id = ?").get(id) as LearningRow | null
@@ -148,7 +153,12 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
     },
     async addGoldenRule(rule) {
       const now = new Date().toISOString()
-      addGoldenRuleTx({ ...rule, id: crypto.randomUUID(), created_at: now, updated_at: now })
+      addGoldenRuleTx({
+        ...rule,
+        id: rule.id || crypto.randomUUID(),
+        created_at: rule.created_at || now,
+        updated_at: rule.updated_at || now,
+      })
     },
     async getGoldenRules(domain) {
       const query = domain

--- a/src/tools/elf/tool.test.ts
+++ b/src/tools/elf/tool.test.ts
@@ -130,6 +130,7 @@ describe("#given ELF tool", () => {
         expect(parsed.id).toBeString()
         expect(parsed.status).toBe("added")
         expect(parsed.deduplicated).toBe(false)
+        expect(await storage.getLearning(parsed.id)).not.toBeNull()
       })
 
       it("adds a golden_rule type", async () => {
@@ -148,6 +149,33 @@ describe("#given ELF tool", () => {
         const parsed = JSON.parse(result as string)
         expect(parsed.id).toBeString()
         expect(parsed.status).toBe("added")
+        const stored = await storage.getGoldenRules("global")
+        expect(stored.some((rule) => rule.id === parsed.id)).toBeTrue()
+      })
+
+      it("does not apply hash-based dedup to golden rules", async () => {
+        const deps = {
+          ...makeDeps(db),
+          findExistingByHash: (_hash: string, _db: Database) => "existing-golden-rule-id",
+        }
+        const tool = createElfTool(deps)
+
+        const result = await tool.execute(
+          {
+            action: "add-rule",
+            content: "Always validate config before startup",
+            type: "golden_rule",
+            scope: "project",
+          },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("added")
+        expect(parsed.deduplicated).toBe(false)
+
+        const stored = await storage.getGoldenRules("project")
+        expect(stored).toHaveLength(1)
       })
 
       it("applies privacy filter before storing", async () => {

--- a/src/tools/elf/tool.ts
+++ b/src/tools/elf/tool.ts
@@ -113,11 +113,14 @@ async function handleAddRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<stri
     })
   }
   const hash = deps.computeContextHash(entryType, scope, filtered)
-  const existingId = deps.findExistingByHash(hash, deps.db)
+  const shouldDeduplicate = entryType !== "golden_rule"
+  const existingId = shouldDeduplicate ? deps.findExistingByHash(hash, deps.db) : null
 
-  if (existingId) {
+  if (shouldDeduplicate && existingId) {
     return JSON.stringify({ deduplicated: true, existingId, status: "duplicate" })
   }
+
+  let id: string | null = null
 
   if (entryType === "golden_rule") {
     await deps.storage.addGoldenRule({
@@ -131,6 +134,7 @@ async function handleAddRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<stri
       created_at: "",
       updated_at: "",
     })
+    id = getLatestGoldenRuleId(filtered, scope, deps.db)
   } else {
     await deps.storage.addLearning({
       id: "",
@@ -147,10 +151,30 @@ async function handleAddRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<stri
       created_at: "",
       updated_at: "",
     })
+    id = getLearningIdByHash(hash, deps.db)
   }
 
-  const id = crypto.randomUUID()
+  if (!id) {
+    return JSON.stringify({ error: "failed to resolve inserted memory id", status: "error" })
+  }
+
   return JSON.stringify({ id, status: "added", deduplicated: false })
+}
+
+function getLatestGoldenRuleId(rule: string, scope: MemoryScope, db: Database): string | null {
+  const row = db
+    .prepare("SELECT id FROM golden_rules WHERE rule = ? AND domain = ? ORDER BY rowid DESC LIMIT 1")
+    .get(rule, scope) as { id: string } | null
+
+  return row?.id ?? null
+}
+
+function getLearningIdByHash(hash: string, db: Database): string | null {
+  const row = db
+    .prepare("SELECT id FROM learnings WHERE context_hash = ? ORDER BY rowid DESC LIMIT 1")
+    .get(hash) as { id: string } | null
+
+  return row?.id ?? null
 }
 
 async function handleMetrics(deps: ElfToolDeps): Promise<string> {

--- a/src/tools/elf/tool.ts
+++ b/src/tools/elf/tool.ts
@@ -112,19 +112,19 @@ async function handleAddRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<stri
       status: "rejected",
     })
   }
-  const hash = deps.computeContextHash(entryType, scope, filtered)
   const shouldDeduplicate = entryType !== "golden_rule"
-  const existingId = shouldDeduplicate ? deps.findExistingByHash(hash, deps.db) : null
+  const hash = shouldDeduplicate ? deps.computeContextHash(entryType, scope, filtered) : null
+  const existingId = hash ? deps.findExistingByHash(hash, deps.db) : null
 
   if (shouldDeduplicate && existingId) {
     return JSON.stringify({ deduplicated: true, existingId, status: "duplicate" })
   }
 
-  let id: string | null = null
+  const id = crypto.randomUUID()
 
   if (entryType === "golden_rule") {
     await deps.storage.addGoldenRule({
-      id: "",
+      id,
       rule: filtered,
       domain: scope,
       confidence: 0.9,
@@ -134,10 +134,9 @@ async function handleAddRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<stri
       created_at: "",
       updated_at: "",
     })
-    id = getLatestGoldenRuleId(filtered, scope, deps.db)
   } else {
     await deps.storage.addLearning({
-      id: "",
+      id,
       type: mapToLearningType(entryType),
       summary: filtered,
       context: "",
@@ -146,35 +145,14 @@ async function handleAddRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<stri
       tags: [],
       utility_score: 0.5,
       times_consulted: 0,
-      context_hash: hash,
+      context_hash: hash!,
       confidence: 0.7,
       created_at: "",
       updated_at: "",
     })
-    id = getLearningIdByHash(hash, deps.db)
-  }
-
-  if (!id) {
-    return JSON.stringify({ error: "failed to resolve inserted memory id", status: "error" })
   }
 
   return JSON.stringify({ id, status: "added", deduplicated: false })
-}
-
-function getLatestGoldenRuleId(rule: string, scope: MemoryScope, db: Database): string | null {
-  const row = db
-    .prepare("SELECT id FROM golden_rules WHERE rule = ? AND domain = ? ORDER BY rowid DESC LIMIT 1")
-    .get(rule, scope) as { id: string } | null
-
-  return row?.id ?? null
-}
-
-function getLearningIdByHash(hash: string, db: Database): string | null {
-  const row = db
-    .prepare("SELECT id FROM learnings WHERE context_hash = ? ORDER BY rowid DESC LIMIT 1")
-    .get(hash) as { id: string } | null
-
-  return row?.id ?? null
 }
 
 async function handleMetrics(deps: ElfToolDeps): Promise<string> {


### PR DESCRIPTION
## Summary
- return the real inserted row id from `elf add-rule` instead of a fresh unrelated UUID
- keep hash-based dedup for learnings only and stop applying it to golden rules until rule-level hash support exists
- add direct ELF tool coverage for stored-id correctness and explicit golden-rule dedup behavior

## Testing
- bun test src/tools/elf/tool.test.ts
- bun run typecheck

Closes #17