### PR TITLE
fix(memory): trigger pre-compaction flush in runtime compaction flows

### DIFF
--- a/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
@@ -241,6 +241,7 @@ describe("executeCompact lock management", () => {
     // Max out all attempts
     autoCompactState.retryStateBySession.set(sessionID, {
       attempt: 5,
+      firstAttemptTime: Date.now(),
       lastAttemptTime: Date.now(),
     })
     autoCompactState.truncateStateBySession.set(sessionID, {
@@ -344,6 +345,32 @@ describe("executeCompact lock management", () => {
 
   test("calls beforeSummarize before summarize retry", async () => {
     const beforeSummarize = mock(async () => {})
+
+    autoCompactState.errorDataBySession.set(sessionID, {
+      errorType: "token_limit",
+      currentTokens: 100000,
+      maxTokens: 200000,
+    })
+
+    await executeCompact(
+      sessionID,
+      msg,
+      autoCompactState,
+      mockClient,
+      directory,
+      undefined,
+      undefined,
+      beforeSummarize,
+    )
+
+    expect(beforeSummarize).toHaveBeenCalledWith(sessionID)
+    expect(mockClient.session.summarize).toHaveBeenCalled()
+  })
+
+  test("continues summarize retry when beforeSummarize fails", async () => {
+    const beforeSummarize = mock(async () => {
+      throw new Error("flush failed")
+    })
 
     autoCompactState.errorDataBySession.set(sessionID, {
       errorType: "token_limit",

--- a/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/executor.test.ts
@@ -342,6 +342,30 @@ describe("executeCompact lock management", () => {
     truncateSpy.mockRestore()
   })
 
+  test("calls beforeSummarize before summarize retry", async () => {
+    const beforeSummarize = mock(async () => {})
+
+    autoCompactState.errorDataBySession.set(sessionID, {
+      errorType: "token_limit",
+      currentTokens: 100000,
+      maxTokens: 200000,
+    })
+
+    await executeCompact(
+      sessionID,
+      msg,
+      autoCompactState,
+      mockClient,
+      directory,
+      undefined,
+      undefined,
+      beforeSummarize,
+    )
+
+    expect(beforeSummarize).toHaveBeenCalledWith(sessionID)
+    expect(mockClient.session.summarize).toHaveBeenCalled()
+  })
+
   test("does NOT call summarize when truncation is sufficient", async () => {
     // given: Over token limit with truncation returning sufficient
     autoCompactState.errorDataBySession.set(sessionID, {

--- a/src/hooks/anthropic-context-window-limit-recovery/executor.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/executor.ts
@@ -18,8 +18,9 @@ export async function executeCompact(
   autoCompactState: AutoCompactState,
   client: Client,
   directory: string,
-  pluginConfig: OpenCodeCrewConfig,
-  _experimental?: ExperimentalConfig
+  pluginConfig?: OpenCodeCrewConfig,
+  _experimental?: ExperimentalConfig,
+  beforeSummarize?: (sessionID: string) => Promise<void>
 ): Promise<void> {
   void _experimental
 
@@ -76,6 +77,7 @@ export async function executeCompact(
       pluginConfig,
       errorType: errorData?.errorType,
       messageIndex: errorData?.messageIndex,
+      beforeSummarize,
     })
   } finally {
     autoCompactState.compactionInProgress.delete(sessionID);

--- a/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/recovery-hook.ts
@@ -10,6 +10,7 @@ import { log } from "@/shared/logger"
 export interface AnthropicContextWindowLimitRecoveryOptions {
   experimental?: ExperimentalConfig
   pluginConfig: OpenCodeCrewConfig
+  beforeSummarize?: (sessionID: string) => Promise<void>
 }
 
 function createRecoveryState(): AutoCompactState {
@@ -30,7 +31,7 @@ export function createAnthropicContextWindowLimitRecoveryHook(
 ) {
   const autoCompactState = createRecoveryState()
   const experimental = options?.experimental
-  const pluginConfig = options?.pluginConfig!
+  const pluginConfig = options?.pluginConfig ?? {}
   const pendingCompactionTimeoutBySession = new Map<string, ReturnType<typeof setTimeout>>()
 
   const eventHandler = async ({ event }: { event: { type: string; properties?: unknown } }) => {
@@ -96,6 +97,7 @@ export function createAnthropicContextWindowLimitRecoveryHook(
             ctx.directory,
             pluginConfig,
             experimental,
+            options?.beforeSummarize,
           )
         }, 300)
 
@@ -164,6 +166,7 @@ export function createAnthropicContextWindowLimitRecoveryHook(
         ctx.directory,
         pluginConfig,
         experimental,
+        options?.beforeSummarize,
       )
     }
   }

--- a/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
@@ -110,7 +110,11 @@ export async function runSummarizeRetryStrategy(params: {
         )
 
         const summarizeBody = { providerID: targetProviderID, modelID: targetModelID, auto: true }
-        await params.beforeSummarize?.(params.sessionID)
+        if (params.beforeSummarize) {
+          try {
+            await params.beforeSummarize(params.sessionID)
+          } catch {}
+        }
         await params.client.session.summarize({
           path: { id: params.sessionID },
           body: summarizeBody as never,

--- a/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
+++ b/src/hooks/anthropic-context-window-limit-recovery/summarize-retry-strategy.ts
@@ -15,9 +15,10 @@ export async function runSummarizeRetryStrategy(params: {
   autoCompactState: AutoCompactState
   client: Client
   directory: string
-  pluginConfig: OpenCodeCrewConfig
+  pluginConfig?: OpenCodeCrewConfig
   errorType?: string
   messageIndex?: number
+  beforeSummarize?: (sessionID: string) => Promise<void>
 }): Promise<void> {
   const retryState = getOrCreateRetryState(params.autoCompactState, params.sessionID)
   const now = Date.now()
@@ -102,13 +103,14 @@ export async function runSummarizeRetryStrategy(params: {
           .catch(() => {})
 
         const { providerID: targetProviderID, modelID: targetModelID } = resolveCompactionModel(
-          params.pluginConfig,
+          params.pluginConfig ?? {},
           params.sessionID,
           providerID,
           modelID
         )
 
         const summarizeBody = { providerID: targetProviderID, modelID: targetModelID, auto: true }
+        await params.beforeSummarize?.(params.sessionID)
         await params.client.session.summarize({
           path: { id: params.sessionID },
           body: summarizeBody as never,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -52,4 +52,4 @@ export { createMemoryLearningHook, type MemoryLearningDeps } from "./memory-lear
 export { createMemoryDecisionDetectionHook, type MemoryDecisionDetectionDeps } from "./memory-decision-detection"
 export { createMemoryInjectionHook, type MemoryInjectionDeps } from "./memory-injection"
 export { createHeartbeatPrunerHook } from "./heartbeat-pruner"
-export { createMemoryPreCompactionFlushHook, type MemoryPreCompactionFlushDeps } from "./memory-pre-compaction-flush"
+export { createMemoryPreCompactionFlushHook, flushPendingMemories, type MemoryPreCompactionFlushDeps } from "./memory-pre-compaction-flush"

--- a/src/hooks/memory-pre-compaction-flush/hook.ts
+++ b/src/hooks/memory-pre-compaction-flush/hook.ts
@@ -6,18 +6,25 @@ export interface MemoryPreCompactionFlushDeps {
   autoCapture?: AutoCaptureConfig
 }
 
+export async function flushPendingMemories(
+  onIdle: () => Promise<void>,
+  autoCapture?: AutoCaptureConfig
+): Promise<void> {
+  if (autoCapture?.pre_compaction_flush === false) return
+
+  try {
+    await onIdle()
+  } catch (error) {
+    log("[memory-pre-compaction-flush] Failed to flush pending memories", {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
 export function createMemoryPreCompactionFlushHook(deps: MemoryPreCompactionFlushDeps) {
   return {
     async flush(): Promise<void> {
-      if (deps.autoCapture?.pre_compaction_flush === false) return
-
-      try {
-        await deps.onIdle()
-      } catch (error) {
-        log("[memory-pre-compaction-flush] Failed to flush pending memories", {
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
+      await flushPendingMemories(deps.onIdle, deps.autoCapture)
     },
   }
 }

--- a/src/hooks/memory-pre-compaction-flush/index.ts
+++ b/src/hooks/memory-pre-compaction-flush/index.ts
@@ -1,1 +1,1 @@
-export { createMemoryPreCompactionFlushHook, type MemoryPreCompactionFlushDeps } from "./hook"
+export { createMemoryPreCompactionFlushHook, flushPendingMemories, type MemoryPreCompactionFlushDeps } from "./hook"

--- a/src/hooks/preemptive-compaction/hook.test.ts
+++ b/src/hooks/preemptive-compaction/hook.test.ts
@@ -168,6 +168,44 @@ describe("preemptive-compaction", () => {
     expect(ctx.client.session.summarize).toHaveBeenCalled()
   })
 
+  it("should flush pending memories before summarize", async () => {
+    const beforeSummarize = mock(async () => {})
+    const hook = createPreemptiveCompactionHook(ctx as never, {} as never, undefined, {
+      beforeSummarize,
+    })
+    const sessionID = "ses_flush"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            tokens: {
+              input: 170000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    const output = { title: "", output: "test", metadata: null }
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      output
+    )
+
+    expect(beforeSummarize).toHaveBeenCalledWith(sessionID)
+    expect(ctx.client.session.summarize).toHaveBeenCalled()
+  })
+
   it("should trigger compaction for google-vertex-anthropic provider", async () => {
     //#given google-vertex-anthropic usage above threshold
     const hook = createPreemptiveCompactionHook(ctx as never, {} as never)

--- a/src/hooks/preemptive-compaction/hook.test.ts
+++ b/src/hooks/preemptive-compaction/hook.test.ts
@@ -206,6 +206,46 @@ describe("preemptive-compaction", () => {
     expect(ctx.client.session.summarize).toHaveBeenCalled()
   })
 
+  it("should continue summarizing when beforeSummarize fails", async () => {
+    const beforeSummarize = mock(async () => {
+      throw new Error("flush failed")
+    })
+    const hook = createPreemptiveCompactionHook(ctx as never, {} as never, undefined, {
+      beforeSummarize,
+    })
+    const sessionID = "ses_flush_failure"
+
+    await hook.event({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: {
+            role: "assistant",
+            sessionID,
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            finish: true,
+            tokens: {
+              input: 170000,
+              output: 1000,
+              reasoning: 0,
+              cache: { read: 10000, write: 0 },
+            },
+          },
+        },
+      },
+    })
+
+    const output = { title: "", output: "test", metadata: null }
+    await hook["tool.execute.after"](
+      { tool: "bash", sessionID, callID: "call_1" },
+      output
+    )
+
+    expect(beforeSummarize).toHaveBeenCalledWith(sessionID)
+    expect(ctx.client.session.summarize).toHaveBeenCalled()
+  })
+
   it("should trigger compaction for google-vertex-anthropic provider", async () => {
     //#given google-vertex-anthropic usage above threshold
     const hook = createPreemptiveCompactionHook(ctx as never, {} as never)

--- a/src/hooks/preemptive-compaction/hook.ts
+++ b/src/hooks/preemptive-compaction/hook.ts
@@ -76,6 +76,7 @@ export function createPreemptiveCompactionHook(
   ctx: PluginInput,
   pluginConfig: OpenCodeCrewConfig,
   modelCacheState?: ModelCacheStateLike,
+  deps?: { beforeSummarize?: (sessionID: string) => Promise<void> },
 ) {
   const compactionInProgress = new Set<string>()
   const compactedSessions = new Set<string>()
@@ -110,6 +111,8 @@ export function createPreemptiveCompactionHook(
     compactionInProgress.add(sessionID)
 
     try {
+      await deps?.beforeSummarize?.(sessionID)
+
       const { providerID: targetProviderID, modelID: targetModelID } = resolveCompactionModel(
         pluginConfig,
         sessionID,

--- a/src/hooks/preemptive-compaction/hook.ts
+++ b/src/hooks/preemptive-compaction/hook.ts
@@ -111,7 +111,16 @@ export function createPreemptiveCompactionHook(
     compactionInProgress.add(sessionID)
 
     try {
-      await deps?.beforeSummarize?.(sessionID)
+      if (deps?.beforeSummarize) {
+        try {
+          await deps.beforeSummarize(sessionID)
+        } catch (error) {
+          log("[preemptive-compaction] beforeSummarize failed (continuing to summarize)", {
+            sessionID,
+            error: String(error),
+          })
+        }
+      }
 
       const { providerID: targetProviderID, modelID: targetModelID } = resolveCompactionModel(
         pluginConfig,

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -78,6 +78,9 @@ export function createSessionHooks(args: {
   const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
 
   const flushBeforeSummarize = async (sessionID: string): Promise<void> => {
+    if (pluginConfig.memory?.enabled === false) return
+    if (pluginConfig.memory?.auto_capture?.pre_compaction_flush === false) return
+
     try {
       const { getMemoryManager } = require("../../features/memory/manager")
       const manager = getMemoryManager()

--- a/src/plugin/hooks/create-session-hooks.ts
+++ b/src/plugin/hooks/create-session-hooks.ts
@@ -27,6 +27,7 @@ import {
   createRuntimeFallbackHook,
   createMemoryLearningHook,
   createMemoryDecisionDetectionHook,
+  flushPendingMemories,
 } from "@/hooks"
 import { createAnthropicEffortHook } from "@/hooks/anthropic-effort"
 import {
@@ -76,6 +77,19 @@ export function createSessionHooks(args: {
 }): SessionHooks {
   const { ctx, pluginConfig, modelCacheState, isHookEnabled, safeHookEnabled } = args
 
+  const flushBeforeSummarize = async (sessionID: string): Promise<void> => {
+    try {
+      const { getMemoryManager } = require("../../features/memory/manager")
+      const manager = getMemoryManager()
+      await flushPendingMemories(() => manager.onIdle(), pluginConfig.memory?.auto_capture)
+    } catch (error) {
+      log("[memory-pre-compaction-flush] Failed to wire runtime flush", {
+        sessionID,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
   const contextWindowMonitor = hookSlot("context-window-monitor", () => createContextWindowMonitorHook(ctx, modelCacheState), isHookEnabled, safeHookEnabled)
 
   // OUTLIER: Double gate - requires both hook enabled AND experimental config flag
@@ -84,7 +98,7 @@ export function createSessionHooks(args: {
     pluginConfig.experimental?.preemptive_compaction
       ? safeCreateHook(
           "preemptive-compaction",
-          () => createPreemptiveCompactionHook(ctx, pluginConfig, modelCacheState),
+          () => createPreemptiveCompactionHook(ctx, pluginConfig, modelCacheState, { beforeSummarize: flushBeforeSummarize }),
           { enabled: safeHookEnabled },
         )
       : null
@@ -180,7 +194,7 @@ export function createSessionHooks(args: {
       )
     : null
 
-  const anthropicContextWindowLimitRecovery = hookSlot("anthropic-context-window-limit-recovery", () => createAnthropicContextWindowLimitRecoveryHook(ctx, { experimental: pluginConfig.experimental, pluginConfig }), isHookEnabled, safeHookEnabled)
+  const anthropicContextWindowLimitRecovery = hookSlot("anthropic-context-window-limit-recovery", () => createAnthropicContextWindowLimitRecoveryHook(ctx, { experimental: pluginConfig.experimental, pluginConfig, beforeSummarize: flushBeforeSummarize }), isHookEnabled, safeHookEnabled)
   const autoUpdateChecker = hookSlot("auto-update-checker", () => createAutoUpdateCheckerHook(ctx, { showStartupToast: isHookEnabled("startup-toast"), isCaptainEnabled: pluginConfig.captain_agent?.disabled !== true, autoUpdate: pluginConfig.auto_update ?? true }), isHookEnabled, safeHookEnabled)
   const agentUsageReminder = hookSlot("agent-usage-reminder", () => createAgentUsageReminderHook(ctx), isHookEnabled, safeHookEnabled)
   const nonInteractiveEnv = hookSlot("non-interactive-env", () => createNonInteractiveEnvHook(ctx), isHookEnabled, safeHookEnabled)


### PR DESCRIPTION
## Summary
- extract the pending-memory flush into a reusable helper instead of keeping it trapped behind the continuation-only hook instance
- run that flush before preemptive compaction summarize calls and before Anthropic recovery summarize retries
- wire the shared flush callback into session hook construction and add direct regression coverage for both runtime compaction paths

## Testing
- bun test src/hooks/preemptive-compaction/hook.test.ts src/hooks/anthropic-context-window-limit-recovery/executor.test.ts src/hooks/memory-pre-compaction-flush/hook.test.ts
- bun run typecheck

Closes #16