### PR TITLE
fix(memory): enforce privacy and file-skipping guarantees in auto-capture

### DIFF
--- a/src/features/memory/privacy-filter.test.ts
+++ b/src/features/memory/privacy-filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import {
+  extractFilePaths,
   filterContent,
   shouldSkipTool,
   shouldSkipFile,
@@ -179,6 +180,30 @@ describe("#given shouldSkipFile", () => {
     it("#then handles full paths with sensitive files", () => {
       expect(shouldSkipFile("/config/prod/.env.production")).toBe(true);
       expect(shouldSkipFile("C:\\project\\credentials.json")).toBe(true);
+    });
+  });
+});
+
+describe("#given extractFilePaths", () => {
+  describe("#when metadata contains common path fields", () => {
+    it("#then returns top-level file path values", () => {
+      const paths = extractFilePaths({
+        filePath: "/tmp/.env",
+        filepath: "/tmp/credentials.json",
+      });
+
+      expect(paths.sort()).toEqual(["/tmp/.env", "/tmp/credentials.json"].sort());
+    });
+
+    it("#then returns nested filediff path values", () => {
+      const paths = extractFilePaths({
+        filediff: {
+          file: "/tmp/private.pem",
+          path: "/tmp/.ssh/id_rsa",
+        },
+      });
+
+      expect(paths.sort()).toEqual(["/tmp/private.pem", "/tmp/.ssh/id_rsa"].sort());
     });
   });
 });

--- a/src/features/memory/privacy-filter.ts
+++ b/src/features/memory/privacy-filter.ts
@@ -93,3 +93,41 @@ export function shouldSkipFile(filePath: string): boolean {
 
   return false;
 }
+
+export function extractFilePaths(metadata: unknown): string[] {
+  if (!metadata || typeof metadata !== "object") {
+    return [];
+  }
+
+  const paths: string[] = [];
+  const candidates = ["filepath", "filePath", "path", "file"];
+
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== "object") return;
+
+    const objectValue = value as Record<string, unknown>;
+    for (const key of candidates) {
+      const candidate = objectValue[key];
+      if (typeof candidate === "string" && candidate.length > 0) {
+        paths.push(candidate);
+      }
+      if (Array.isArray(candidate)) {
+        for (const item of candidate) {
+          if (typeof item === "string" && item.length > 0) {
+            paths.push(item);
+          }
+        }
+      }
+    }
+
+    for (const nestedValue of Object.values(objectValue)) {
+      if (nestedValue && typeof nestedValue === "object") {
+        visit(nestedValue);
+      }
+    }
+  };
+
+  visit(metadata);
+
+  return Array.from(new Set(paths));
+}

--- a/src/hooks/memory-learning/hook.test.ts
+++ b/src/hooks/memory-learning/hook.test.ts
@@ -322,6 +322,62 @@ describe("memory-learning hook", () => {
     })
   })
 
+  describe("#given output metadata references a sensitive file", () => {
+    test("skips capture when metadata.filePath points to a skipped file", async () => {
+      //#given
+      const hook = createMemoryLearningHook({ storage })
+      const input = { tool: "Edit", sessionID: "ses_sensitive_1", callID: "call_sensitive_1" }
+      const output = {
+        title: "edited file",
+        output: "Updated .env secrets",
+        metadata: { attempt: 2, filePath: "/tmp/.env" } as Record<string, unknown>,
+      }
+
+      //#when
+      await hook["tool.execute.after"](input, output)
+
+      //#then
+      expect(storage.learnings).toHaveLength(0)
+    })
+
+    test("skips capture when metadata.filediff references a skipped file", async () => {
+      //#given
+      const hook = createMemoryLearningHook({ storage })
+      const input = { tool: "Write", sessionID: "ses_sensitive_2", callID: "call_sensitive_2" }
+      const output = {
+        title: "written file",
+        output: "Wrote ssh key",
+        metadata: {
+          attempt: 2,
+          filediff: { file: "/tmp/private.pem", path: "/tmp/private.pem" },
+        } as Record<string, unknown>,
+      }
+
+      //#when
+      await hook["tool.execute.after"](input, output)
+
+      //#then
+      expect(storage.learnings).toHaveLength(0)
+    })
+
+    test("still captures when metadata points to a non-sensitive file", async () => {
+      //#given
+      const hook = createMemoryLearningHook({ storage })
+      const input = { tool: "Edit", sessionID: "ses_sensitive_3", callID: "call_sensitive_3" }
+      const output = {
+        title: "edited file",
+        output: "Updated src/app.ts",
+        metadata: { attempt: 2, filePath: "/tmp/src/app.ts" } as Record<string, unknown>,
+      }
+
+      //#when
+      await hook["tool.execute.after"](input, output)
+
+      //#then
+      expect(storage.learnings).toHaveLength(1)
+    })
+  })
+
   describe("#given a learning is captured", () => {
     test("sets initial utility_score=0.5 and confidence=0.5", async () => {
       //#given

--- a/src/hooks/memory-learning/hook.ts
+++ b/src/hooks/memory-learning/hook.ts
@@ -1,6 +1,6 @@
 import type { IMemoryStorage, Learning, LearningType, MemoryScope } from "@/features/memory/types"
 import type { AutoCaptureConfig } from "@/config/schema/memory"
-import { filterContent, shouldSkipTool } from "@/features/memory/privacy-filter"
+import { extractFilePaths, filterContent, shouldSkipFile, shouldSkipTool } from "@/features/memory/privacy-filter"
 import { log } from "@/shared/logger"
 import { subagentSessions } from "@/features/claude-code-session-state"
 
@@ -126,6 +126,9 @@ export function createMemoryLearningHook(deps: MemoryLearningDeps) {
     "tool.execute.after": async (input: HookInput, output: HookOutput): Promise<void> => {
       if (subagentSessions.has(input.sessionID)) return
       if (!shouldCapture(input.tool, output, deps.autoCapture)) return
+
+      const referencedPaths = extractFilePaths(output?.metadata)
+      if (referencedPaths.some((filePath) => shouldSkipFile(filePath))) return
 
       const summary = buildSummary(input.tool, output!.output)
       const contextHash = computeHash(input.tool, input.sessionID, scope, summary)


### PR DESCRIPTION
## Summary
- extract file path provenance from tool metadata so memory capture can make skip decisions using actual touched files instead of raw output text
- reject auto-capture when metadata points at sensitive files such as `.env`, `.pem`, `.key`, `.ssh`, and `credentials.json`
- add direct coverage for metadata path extraction and sensitive-file suppression in the memory-learning hook

## Testing
- bun test src/features/memory/privacy-filter.test.ts src/hooks/memory-learning/hook.test.ts
- bun run typecheck

Closes #15