### PR TITLE
feat(elf): add delete-rule and update-rule memory operations

### DIFF
--- a/src/features/memory/db/client.ts
+++ b/src/features/memory/db/client.ts
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS golden_rules (
   domain TEXT,
   confidence REAL NOT NULL DEFAULT 0.9,
   times_validated INTEGER DEFAULT 0,
+  times_violated INTEGER DEFAULT 0,
   source_learning_ids TEXT DEFAULT '[]',
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))

--- a/src/features/memory/db/client.ts
+++ b/src/features/memory/db/client.ts
@@ -100,6 +100,25 @@ export function initializeDatabase(dbPath: string): Database {
   return db
 }
 
+function getSchemaVersion(db: Database): number {
+  const row = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as { v: number | null } | null
+  return row?.v ?? 0
+}
+
+function runMigrations(db: Database): void {
+  const current = getSchemaVersion(db)
+
+  if (current < 2) {
+    const columns = db.prepare("PRAGMA table_info(golden_rules)").all() as { name: string }[]
+    const hasTimesViolated = columns.some((c) => c.name === "times_violated")
+    if (!hasTimesViolated) {
+      db.exec("ALTER TABLE golden_rules ADD COLUMN times_violated INTEGER DEFAULT 0")
+      log("[memory] Migration v2: added times_violated column to golden_rules")
+    }
+    db.prepare("INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (2, datetime('now'))").run()
+  }
+}
+
 function openAndValidate(dbPath: string): Database {
   if (dbPath !== ":memory:") {
     mkdirSync(dirname(dbPath), { recursive: true })
@@ -115,6 +134,7 @@ function openAndValidate(dbPath: string): Database {
   db.prepare(
     "INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (1, datetime('now'))"
   ).run()
+  runMigrations(db)
   return db
 }
 

--- a/src/features/memory/scoring/utility-scorer.test.ts
+++ b/src/features/memory/scoring/utility-scorer.test.ts
@@ -127,6 +127,8 @@ describe("#given batchUpdateScores", () => {
           getGoldenRules: mock(() => Promise.resolve([])),
           getGoldenRulesByScope: mock(() => Promise.resolve([])),
           deleteGoldenRule: mock(() => Promise.resolve()),
+          getGoldenRule: mock(() => Promise.resolve(null)),
+          updateGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 
@@ -151,6 +153,8 @@ describe("#given batchUpdateScores", () => {
           getGoldenRules: mock(() => Promise.resolve([])),
           getGoldenRulesByScope: mock(() => Promise.resolve([])),
           deleteGoldenRule: mock(() => Promise.resolve()),
+          getGoldenRule: mock(() => Promise.resolve(null)),
+          updateGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 
@@ -175,6 +179,8 @@ describe("#given batchUpdateScores", () => {
           getGoldenRules: mock(() => Promise.resolve([])),
           getGoldenRulesByScope: mock(() => Promise.resolve([])),
           deleteGoldenRule: mock(() => Promise.resolve()),
+          getGoldenRule: mock(() => Promise.resolve(null)),
+          updateGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 
@@ -201,6 +207,8 @@ describe("#given batchUpdateScores", () => {
           getGoldenRules: mock(() => Promise.resolve([])),
           getGoldenRulesByScope: mock(() => Promise.resolve([])),
           deleteGoldenRule: mock(() => Promise.resolve()),
+          getGoldenRule: mock(() => Promise.resolve(null)),
+          updateGoldenRule: mock(() => Promise.resolve()),
           getStats: mock(() => Promise.resolve({ learnings: 0, goldenRules: 0 })),
         };
 

--- a/src/features/memory/storage/memory-storage.test.ts
+++ b/src/features/memory/storage/memory-storage.test.ts
@@ -258,9 +258,9 @@ describe("#given memory storage", () => {
       })
 
       it("throws for non-existent ID", async () => {
-        expect(async () => {
-          await storage.updateGoldenRule("non-existent-rule", { rule: "New text" })
-        }).toThrow()
+        await expect(
+          storage.updateGoldenRule("non-existent-rule", { rule: "New text" })
+        ).rejects.toThrow()
       })
     })
   })

--- a/src/features/memory/storage/memory-storage.test.ts
+++ b/src/features/memory/storage/memory-storage.test.ts
@@ -162,4 +162,106 @@ describe("#given memory storage", () => {
       })
     })
   })
+
+  describe("#when reading a single golden rule by ID", () => {
+    describe("#then", () => {
+      it("returns the golden rule for a valid ID", async () => {
+        await storage.addGoldenRule({
+          id: "rule-to-fetch",
+          rule: "Always use transactions for database writes",
+          domain: "database",
+          confidence: 0.95,
+          times_validated: 5,
+          times_violated: 0,
+          source_learning_ids: ["learning-1", "learning-2"],
+          created_at: "",
+          updated_at: "",
+        })
+
+        const rule = await storage.getGoldenRule("rule-to-fetch")
+
+        expect(rule).not.toBeNull()
+        expect(rule?.id).toBe("rule-to-fetch")
+        expect(rule?.rule).toBe("Always use transactions for database writes")
+        expect(rule?.domain).toBe("database")
+        expect(rule?.confidence).toBe(0.95)
+        expect(rule?.times_validated).toBe(5)
+        expect(rule?.times_violated).toBe(0)
+        expect(rule?.source_learning_ids).toEqual(["learning-1", "learning-2"])
+        expect(rule?.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+      })
+
+      it("returns null for a non-existent ID", async () => {
+        const rule = await storage.getGoldenRule("non-existent-rule-id")
+        expect(rule).toBeNull()
+      })
+    })
+  })
+
+  describe("#when updating a golden rule", () => {
+    describe("#then", () => {
+      it("updates rule text and syncs FTS index", async () => {
+        await storage.addGoldenRule({
+          id: "rule-to-update",
+          rule: "Old rule text",
+          domain: "testing",
+          confidence: 0.8,
+          times_validated: 2,
+          times_violated: 1,
+          source_learning_ids: ["learning-3"],
+          created_at: "",
+          updated_at: "",
+        })
+
+        await storage.updateGoldenRule("rule-to-update", {
+          rule: "New rule text about deterministic behavior",
+        })
+
+        const updated = await storage.getGoldenRule("rule-to-update")
+        expect(updated?.rule).toBe("New rule text about deterministic behavior")
+
+        const ftsMatches = db
+          .prepare("SELECT rowid FROM golden_rules_fts WHERE golden_rules_fts MATCH ?")
+          .all("deterministic")
+        expect(ftsMatches.length).toBe(1)
+      })
+
+      it("preserves unchanged fields when updating", async () => {
+        await storage.addGoldenRule({
+          id: "rule-partial-update",
+          rule: "Original rule",
+          domain: "architecture",
+          confidence: 0.75,
+          times_validated: 3,
+          times_violated: 0,
+          source_learning_ids: ["learning-4", "learning-5"],
+          created_at: "",
+          updated_at: "",
+        })
+
+        const originalRule = await storage.getGoldenRule("rule-partial-update")
+        const originalCreatedAt = originalRule?.created_at
+
+        await storage.updateGoldenRule("rule-partial-update", {
+          rule: "Modified rule text",
+        })
+
+        const updated = await storage.getGoldenRule("rule-partial-update")
+
+        expect(updated?.rule).toBe("Modified rule text")
+        expect(updated?.domain).toBe("architecture")
+        expect(updated?.confidence).toBe(0.75)
+        expect(updated?.times_validated).toBe(3)
+        expect(updated?.times_violated).toBe(0)
+        expect(updated?.source_learning_ids).toEqual(["learning-4", "learning-5"])
+        expect(updated?.created_at).toBe(originalCreatedAt)
+      })
+
+      it("throws for non-existent ID", async () => {
+        expect(async () => {
+          await storage.updateGoldenRule("non-existent-rule", { rule: "New text" })
+        }).toThrow()
+      })
+    })
+  })
 })

--- a/src/features/memory/storage/memory-storage.ts
+++ b/src/features/memory/storage/memory-storage.ts
@@ -94,10 +94,7 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
       payload.updated_at,
       id
     )
-    db.prepare("DELETE FROM learnings_fts WHERE rowid = ?").run(existing.rowid)
-    db.prepare(
-      "INSERT INTO learnings_fts(rowid, summary, context, tags, tool_name, domain) VALUES (?, ?, ?, ?, ?, ?)"
-    ).run(existing.rowid, merged.summary, merged.context, payload.tags ?? "", merged.tool_name, merged.domain)
+    db.prepare("INSERT INTO learnings_fts(learnings_fts) VALUES('rebuild')").run()
   })
 
   const incrementTimesConsultedTx = db.transaction((id: string) => {
@@ -120,13 +117,14 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
   const addGoldenRuleTx = db.transaction((rule: GoldenRule) => {
     const payload = toGoldenRuleRow(rule)
     db.prepare(
-      "INSERT INTO golden_rules (id, rule, domain, confidence, times_validated, source_learning_ids, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO golden_rules (id, rule, domain, confidence, times_validated, times_violated, source_learning_ids, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
     ).run(
       payload.id,
       payload.rule,
       payload.domain,
       payload.confidence,
       payload.times_validated,
+      payload.times_violated,
       payload.source_learning_ids,
       payload.created_at,
       payload.updated_at
@@ -140,6 +138,33 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
       rule.rule,
       rule.domain
     )
+  })
+
+  const updateGoldenRuleTx = db.transaction((id: string, updates: Partial<GoldenRule>) => {
+    const existing = db.prepare("SELECT rowid, * FROM golden_rules WHERE id = ?").get(id) as GoldenRuleRow | null
+    if (!existing) throw new Error(`Golden rule not found: ${id}`)
+    const now = new Date().toISOString()
+    const merged: GoldenRule = {
+      ...fromGoldenRuleRow(existing),
+      ...updates,
+      id,
+      created_at: existing.created_at,
+      updated_at: now,
+    }
+    const payload = toGoldenRuleRow(merged)
+    db.prepare(
+      "UPDATE golden_rules SET rule = ?, domain = ?, confidence = ?, times_validated = ?, times_violated = ?, source_learning_ids = ?, updated_at = ? WHERE id = ?"
+    ).run(
+      payload.rule,
+      payload.domain,
+      payload.confidence,
+      payload.times_validated,
+      payload.times_violated,
+      payload.source_learning_ids,
+      payload.updated_at,
+      id
+    )
+    db.prepare("INSERT INTO golden_rules_fts(golden_rules_fts) VALUES('rebuild')").run()
   })
 
   return {
@@ -207,6 +232,13 @@ export function createMemoryStorage(db: Database): IMemoryStorage {
       const row = db.prepare("SELECT rowid FROM golden_rules WHERE id = ?").get(id) as { rowid: number } | null
       if (row) db.prepare("DELETE FROM golden_rules_fts WHERE rowid = ?").run(row.rowid)
       db.prepare("DELETE FROM golden_rules WHERE id = ?").run(id)
+    },
+    async getGoldenRule(id) {
+      const row = db.prepare("SELECT rowid, * FROM golden_rules WHERE id = ?").get(id) as GoldenRuleRow | null
+      return row ? fromGoldenRuleRow(row) : null
+    },
+    async updateGoldenRule(id, updates) {
+      updateGoldenRuleTx(id, updates)
     },
   }
 }

--- a/src/features/memory/types.test.ts
+++ b/src/features/memory/types.test.ts
@@ -144,6 +144,8 @@ describe("Memory System Types", () => {
           getGoldenRules: async () => [],
           getGoldenRulesByScope: async () => [],
           deleteGoldenRule: async () => {},
+          getGoldenRule: async () => null,
+          updateGoldenRule: async () => {},
           getStats: async () => ({ learnings: 0, goldenRules: 0 }),
         }
         expect(storage).toBeDefined()

--- a/src/features/memory/types.ts
+++ b/src/features/memory/types.ts
@@ -96,6 +96,8 @@ export interface IMemoryStorage {
   getGoldenRules(domain?: string): Promise<GoldenRule[]>
   getGoldenRulesByScope(scope: MemoryScope): Promise<GoldenRule[]>
   deleteGoldenRule(id: string): Promise<void>
+  getGoldenRule(id: string): Promise<GoldenRule | null>
+  updateGoldenRule(id: string, updates: Partial<GoldenRule>): Promise<void>
   getStats(): Promise<{ learnings: number; goldenRules: number }>
 }
 

--- a/src/hooks/memory-decision-detection/hook.test.ts
+++ b/src/hooks/memory-decision-detection/hook.test.ts
@@ -27,6 +27,8 @@ function createMockStorage(): IMemoryStorage & { goldenRules: GoldenRule[] } {
       return goldenRules
     },
     async deleteGoldenRule(_id: string) {},
+    async getGoldenRule(_id: string) { return null },
+    async updateGoldenRule(_id: string, _updates: Partial<import("../../features/memory/types").GoldenRule>) {},
     async getStats() {
       return { learnings: 0, goldenRules: goldenRules.length }
     },

--- a/src/hooks/memory-integration/integration.test.ts
+++ b/src/hooks/memory-integration/integration.test.ts
@@ -70,6 +70,13 @@ function createMockStorage(): IMemoryStorage & { learnings: Learning[]; goldenRu
         goldenRules.splice(index, 1)
       }
     },
+    async getGoldenRule(id: string) {
+      return goldenRules.find((rule) => rule.id === id) ?? null
+    },
+    async updateGoldenRule(id: string, updates: Partial<import("../../features/memory/types").GoldenRule>) {
+      const rule = goldenRules.find((r) => r.id === id)
+      if (rule) Object.assign(rule, updates)
+    },
     async getStats() {
       return { learnings: learnings.length, goldenRules: goldenRules.length }
     },

--- a/src/hooks/memory-learning/hook.test.ts
+++ b/src/hooks/memory-learning/hook.test.ts
@@ -37,6 +37,8 @@ function createMockStorage(): IMemoryStorage & { learnings: Learning[] } {
       return []
     },
     async deleteGoldenRule(_id: string) {},
+    async getGoldenRule(_id: string) { return null },
+    async updateGoldenRule(_id: string, _updates: Partial<import("../../features/memory/types").GoldenRule>) {},
     async getStats() {
       return { learnings: learnings.length, goldenRules: 0 }
     },

--- a/src/plugin-handlers/memory-config.test.ts
+++ b/src/plugin-handlers/memory-config.test.ts
@@ -19,10 +19,13 @@ function createMockManager(): MemoryManager {
     getLearningsByScope: async () => [],
     updateLearning: async () => {},
     deleteLearning: async () => {},
+    incrementTimesConsulted: async () => {},
     addGoldenRule: async () => {},
     getGoldenRules: async () => [],
     getGoldenRulesByScope: async () => [],
     deleteGoldenRule: async () => {},
+    getGoldenRule: async () => null,
+    updateGoldenRule: async () => {},
     getStats: async () => ({ learnings: 0, goldenRules: 0 }),
   }
   const search: IMemorySearch = {

--- a/src/tools/elf/tool.test.ts
+++ b/src/tools/elf/tool.test.ts
@@ -278,6 +278,333 @@ describe("#given ELF tool", () => {
     })
   })
 
+  describe("#when action is delete-rule", () => {
+    describe("#then it removes memory items and returns confirmation", () => {
+      it("deletes a learning by ID", async () => {
+        const learningId = crypto.randomUUID()
+        await storage.addLearning({
+          id: learningId,
+          type: "success",
+          summary: "Deletion test learning",
+          context: "testing",
+          tool_name: "Test",
+          domain: "project",
+          tags: [],
+          utility_score: 0.5,
+          times_consulted: 0,
+          context_hash: "hash-delete-learning-1",
+          confidence: 0.7,
+          created_at: "",
+          updated_at: "",
+        })
+
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "delete-rule", id: learningId },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("deleted")
+        expect(parsed.type).toBe("learning")
+        expect(parsed.id).toBe(learningId)
+        expect(await storage.getLearning(learningId)).toBeNull()
+      })
+
+      it("deletes a golden_rule by ID", async () => {
+        const ruleId = crypto.randomUUID()
+        await storage.addGoldenRule({
+          id: ruleId,
+          rule: "Always validate input",
+          domain: "project",
+          confidence: 0.9,
+          times_validated: 0,
+          times_violated: 0,
+          source_learning_ids: [],
+          created_at: "",
+          updated_at: "",
+        })
+
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "delete-rule", id: ruleId, type: "golden_rule" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("deleted")
+        expect(parsed.type).toBe("golden_rule")
+      })
+
+      it("returns not_found for nonexistent ID", async () => {
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const fakeId = crypto.randomUUID()
+        const result = await tool.execute(
+          { action: "delete-rule", id: fakeId },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("not_found")
+        expect(parsed.error).toContain("not found")
+      })
+
+      it("returns error when id is missing", async () => {
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "delete-rule" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.error).toContain("id is required")
+      })
+
+      it("auto-detects type when not specified", async () => {
+        const ruleId = crypto.randomUUID()
+        await storage.addGoldenRule({
+          id: ruleId,
+          rule: "Always use golden rules",
+          domain: "global",
+          confidence: 0.9,
+          times_validated: 0,
+          times_violated: 0,
+          source_learning_ids: [],
+          created_at: "",
+          updated_at: "",
+        })
+
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "delete-rule", id: ruleId },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("deleted")
+        expect(parsed.type).toBe("golden_rule")
+      })
+    })
+  })
+
+  describe("#when action is update-rule", () => {
+    describe("#then it updates memory items with validation", () => {
+      it("updates a learning's content", async () => {
+        const learningId = crypto.randomUUID()
+        await storage.addLearning({
+          id: learningId,
+          type: "observation",
+          summary: "Original content",
+          context: "testing",
+          tool_name: "Test",
+          domain: "project",
+          tags: [],
+          utility_score: 0.5,
+          times_consulted: 0,
+          context_hash: "hash-update-learning-1",
+          confidence: 0.7,
+          created_at: "",
+          updated_at: "",
+        })
+
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "update-rule", id: learningId, content: "Updated content" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("updated")
+        expect(parsed.type).toBe("learning")
+        const updated = await storage.getLearning(learningId)
+        expect(updated?.summary).toBe("Updated content")
+      })
+
+      it("updates a golden_rule's content", async () => {
+        const ruleId = crypto.randomUUID()
+        await storage.addGoldenRule({
+          id: ruleId,
+          rule: "Original rule",
+          domain: "project",
+          confidence: 0.9,
+          times_validated: 0,
+          times_violated: 0,
+          source_learning_ids: [],
+          created_at: "",
+          updated_at: "",
+        })
+
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "update-rule", id: ruleId, content: "Updated rule", type: "golden_rule" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("updated")
+        expect(parsed.type).toBe("golden_rule")
+        const updated = await storage.getGoldenRule(ruleId)
+        expect(updated?.rule).toBe("Updated rule")
+      })
+
+      it("returns not_found for nonexistent ID", async () => {
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const fakeId = crypto.randomUUID()
+        const result = await tool.execute(
+          { action: "update-rule", id: fakeId, content: "New content" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("not_found")
+        expect(parsed.error).toContain("not found")
+      })
+
+      it("returns error when id is missing", async () => {
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "update-rule", content: "Content without ID" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.error).toContain("id is required")
+      })
+
+      it("returns error when content is missing", async () => {
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "update-rule", id: crypto.randomUUID() },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.error).toContain("content is required")
+      })
+
+      it("applies privacy filter before updating", async () => {
+        const learningId = crypto.randomUUID()
+        await storage.addLearning({
+          id: learningId,
+          type: "observation",
+          summary: "Original",
+          context: "testing",
+          tool_name: "Test",
+          domain: "project",
+          tags: [],
+          utility_score: 0.5,
+          times_consulted: 0,
+          context_hash: "hash-privacy-filter-1",
+          confidence: 0.7,
+          created_at: "",
+          updated_at: "",
+        })
+
+        let filteredContent = ""
+        const deps = {
+          ...makeDeps(db),
+          filterContent: (content: string, _tags: string[]) => {
+            filteredContent = content.replace(/AKIA[0-9A-Z]{16}/g, "[REDACTED]")
+            return filteredContent
+          },
+        }
+        const tool = createElfTool(deps)
+        await tool.execute(
+          { action: "update-rule", id: learningId, content: "Found key AKIAIOSFODNN7EXAMPLE in config" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        expect(filteredContent).toContain("[REDACTED]")
+        const updated = await storage.getLearning(learningId)
+        expect(updated?.summary).toContain("[REDACTED]")
+      })
+
+      it("rejects memory-dump shaped content", async () => {
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          {
+            action: "update-rule",
+            id: crypto.randomUUID(),
+            content: "## Agent Memory\n### Golden Rules\n- Rule A\n### Learnings\n- Item B\ntotalMemories: 4\nbyType: {'learnings':1,'golden_rules':3}",
+          },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("rejected")
+        expect(parsed.error).toContain("memory dump")
+      })
+
+      it("updates scope when provided", async () => {
+        const learningId = crypto.randomUUID()
+        await storage.addLearning({
+          id: learningId,
+          type: "observation",
+          summary: "Original with project scope",
+          context: "testing",
+          tool_name: "Test",
+          domain: "project",
+          tags: [],
+          utility_score: 0.5,
+          times_consulted: 0,
+          context_hash: "hash-scope-update-1",
+          confidence: 0.7,
+          created_at: "",
+          updated_at: "",
+        })
+
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "update-rule", id: learningId, content: "Updated content", scope: "global" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("updated")
+        const updated = await storage.getLearning(learningId)
+        expect(updated?.domain).toBe("global")
+      })
+
+      it("auto-detects type when not specified", async () => {
+        const ruleId = crypto.randomUUID()
+        await storage.addGoldenRule({
+          id: ruleId,
+          rule: "Auto-detect test",
+          domain: "project",
+          confidence: 0.9,
+          times_validated: 0,
+          times_violated: 0,
+          source_learning_ids: [],
+          created_at: "",
+          updated_at: "",
+        })
+
+        const deps = makeDeps(db)
+        const tool = createElfTool(deps)
+        const result = await tool.execute(
+          { action: "update-rule", id: ruleId, content: "Updated without type" },
+          {} as Parameters<typeof tool.execute>[1]
+        )
+
+        const parsed = JSON.parse(result as string)
+        expect(parsed.status).toBe("updated")
+        expect(parsed.type).toBe("golden_rule")
+      })
+    })
+  })
+
   describe("#when action is unknown", () => {
     describe("#then it returns a helpful error", () => {
       it("returns error with valid actions listed", async () => {
@@ -293,6 +620,8 @@ describe("#given ELF tool", () => {
         expect(result).toContain("search")
         expect(result).toContain("add-rule")
         expect(result).toContain("metrics")
+        expect(result).toContain("delete-rule")
+        expect(result).toContain("update-rule")
       })
     })
   })

--- a/src/tools/elf/tool.ts
+++ b/src/tools/elf/tool.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite"
 import { tool } from "@opencode-ai/plugin"
-import type { IMemoryStorage, LearningType, MemoryScope } from "@/features/memory/types"
+import type { GoldenRule, IMemoryStorage, Learning, LearningType, MemoryScope } from "@/features/memory/types"
 import type { SearchOptions } from "@/features/memory/search/search-service"
 import type { MemorySearchResult } from "@/features/memory/types"
 import { isLikelyMemoryDump } from "@/features/memory/memory-dump-detector"
@@ -232,7 +232,7 @@ async function handleUpdateRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<s
     if (!existing) {
       return JSON.stringify({ error: `Golden rule not found: ${args.id}`, status: "not_found" })
     }
-    const updates: Record<string, string> = { rule: filtered }
+    const updates: Partial<GoldenRule> = { rule: filtered }
     if (args.scope) updates.domain = args.scope
     await deps.storage.updateGoldenRule(args.id, updates)
     return JSON.stringify({ id: args.id, status: "updated", type: "golden_rule" })
@@ -243,7 +243,7 @@ async function handleUpdateRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<s
     if (!existing) {
       return JSON.stringify({ error: `Learning not found: ${args.id}`, status: "not_found" })
     }
-    const updates: Record<string, string> = { summary: filtered }
+    const updates: Partial<Learning> = { summary: filtered }
     if (args.scope) updates.domain = args.scope
     await deps.storage.updateLearning(args.id, updates)
     return JSON.stringify({ id: args.id, status: "updated", type: "learning" })
@@ -252,7 +252,7 @@ async function handleUpdateRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<s
   // Auto-detect: try learning first, then golden rule
   const learning = await deps.storage.getLearning(args.id)
   if (learning) {
-    const updates: Record<string, string> = { summary: filtered }
+    const updates: Partial<Learning> = { summary: filtered }
     if (args.scope) updates.domain = args.scope
     await deps.storage.updateLearning(args.id, updates)
     return JSON.stringify({ id: args.id, status: "updated", type: "learning" })
@@ -260,7 +260,7 @@ async function handleUpdateRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<s
 
   const goldenRule = await deps.storage.getGoldenRule(args.id)
   if (goldenRule) {
-    const updates: Record<string, string> = { rule: filtered }
+    const updates: Partial<GoldenRule> = { rule: filtered }
     if (args.scope) updates.domain = args.scope
     await deps.storage.updateGoldenRule(args.id, updates)
     return JSON.stringify({ id: args.id, status: "updated", type: "golden_rule" })

--- a/src/tools/elf/tool.ts
+++ b/src/tools/elf/tool.ts
@@ -30,11 +30,14 @@ interface ElfToolArgs {
   scope?: MemoryScope
   limit?: number
   content?: string
+  id?: string
 }
 
 const DESCRIPTION = `Emergent Learning Framework (ELF) memory tool. Actions:
 - search: Query memory for relevant learnings/rules. Params: query (required), type?, scope?, limit?
 - add-rule: Store a new learning or golden rule. Params: content (required), type (golden_rule|learning|fact), scope?
+- delete-rule: Remove a memory item by ID. Params: id (required), type? (learning|golden_rule)
+- update-rule: Update a memory item by ID. Params: id (required), content (required), type?, scope?
 - metrics: Get memory system statistics. No params needed.`
 
 const PRIVACY_TAGS = ["private", "secret", "credential"]
@@ -44,12 +47,13 @@ export function createElfTool(deps: ElfToolDeps) {
   return tool({
     description: DESCRIPTION,
     args: {
-      action: tool.schema.string().describe("Action: search, add-rule, or metrics"),
+      action: tool.schema.string().describe("Action: search, add-rule, delete-rule, update-rule, or metrics"),
       query: tool.schema.string().optional().describe("Search query (required for search)"),
       type: tool.schema.string().optional().describe("Memory type filter or entry type"),
       scope: tool.schema.string().optional().describe("project or global scope"),
       limit: tool.schema.number().optional().describe("Max results for search"),
       content: tool.schema.string().optional().describe("Content for add-rule action"),
+      id: tool.schema.string().optional().describe("Memory item ID for delete/update operations"),
     },
     async execute(args: ElfToolArgs) {
       switch (args.action) {
@@ -59,8 +63,12 @@ export function createElfTool(deps: ElfToolDeps) {
           return handleAddRule(deps, args)
         case "metrics":
           return handleMetrics(deps)
+        case "delete-rule":
+          return handleDeleteRule(deps, args)
+        case "update-rule":
+          return handleUpdateRule(deps, args)
         default:
-          return `Unknown action "${args.action}". Valid actions: search, add-rule, metrics`
+          return `Unknown action "${args.action}". Valid actions: search, add-rule, delete-rule, update-rule, metrics`
       }
     },
   })
@@ -162,6 +170,103 @@ async function handleAddRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<stri
   }
 
   return JSON.stringify({ id, status: "added", deduplicated: false })
+}
+
+async function handleDeleteRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<string> {
+  if (!args.id) {
+    return JSON.stringify({ error: "id is required for delete-rule action" })
+  }
+
+  if (args.type === "golden_rule") {
+    const existing = await deps.storage.getGoldenRule(args.id)
+    if (!existing) {
+      return JSON.stringify({ error: `Golden rule not found: ${args.id}`, status: "not_found" })
+    }
+    await deps.storage.deleteGoldenRule(args.id)
+    return JSON.stringify({ id: args.id, status: "deleted", type: "golden_rule" })
+  }
+
+  if (args.type === "learning") {
+    const existing = await deps.storage.getLearning(args.id)
+    if (!existing) {
+      return JSON.stringify({ error: `Learning not found: ${args.id}`, status: "not_found" })
+    }
+    await deps.storage.deleteLearning(args.id)
+    return JSON.stringify({ id: args.id, status: "deleted", type: "learning" })
+  }
+
+  // Auto-detect: try learning first, then golden rule
+  const learning = await deps.storage.getLearning(args.id)
+  if (learning) {
+    await deps.storage.deleteLearning(args.id)
+    return JSON.stringify({ id: args.id, status: "deleted", type: "learning" })
+  }
+
+  const goldenRule = await deps.storage.getGoldenRule(args.id)
+  if (goldenRule) {
+    await deps.storage.deleteGoldenRule(args.id)
+    return JSON.stringify({ id: args.id, status: "deleted", type: "golden_rule" })
+  }
+
+  return JSON.stringify({ error: `Memory item not found: ${args.id}`, status: "not_found" })
+}
+
+async function handleUpdateRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<string> {
+  if (!args.id) {
+    return JSON.stringify({ error: "id is required for update-rule action" })
+  }
+  if (!args.content) {
+    return JSON.stringify({ error: "content is required for update-rule action" })
+  }
+
+  const filtered = deps.filterContent(args.content, PRIVACY_TAGS)
+  if (isLikelyMemoryDump(filtered)) {
+    return JSON.stringify({
+      error: "content appears to be a memory dump transcript and was rejected",
+      status: "rejected",
+    })
+  }
+
+  if (args.type === "golden_rule") {
+    const existing = await deps.storage.getGoldenRule(args.id)
+    if (!existing) {
+      return JSON.stringify({ error: `Golden rule not found: ${args.id}`, status: "not_found" })
+    }
+    const updates: Record<string, string> = { rule: filtered }
+    if (args.scope) updates.domain = args.scope
+    await deps.storage.updateGoldenRule(args.id, updates)
+    return JSON.stringify({ id: args.id, status: "updated", type: "golden_rule" })
+  }
+
+  if (args.type === "learning") {
+    const existing = await deps.storage.getLearning(args.id)
+    if (!existing) {
+      return JSON.stringify({ error: `Learning not found: ${args.id}`, status: "not_found" })
+    }
+    const updates: Record<string, string> = { summary: filtered }
+    if (args.scope) updates.domain = args.scope
+    await deps.storage.updateLearning(args.id, updates)
+    return JSON.stringify({ id: args.id, status: "updated", type: "learning" })
+  }
+
+  // Auto-detect: try learning first, then golden rule
+  const learning = await deps.storage.getLearning(args.id)
+  if (learning) {
+    const updates: Record<string, string> = { summary: filtered }
+    if (args.scope) updates.domain = args.scope
+    await deps.storage.updateLearning(args.id, updates)
+    return JSON.stringify({ id: args.id, status: "updated", type: "learning" })
+  }
+
+  const goldenRule = await deps.storage.getGoldenRule(args.id)
+  if (goldenRule) {
+    const updates: Record<string, string> = { rule: filtered }
+    if (args.scope) updates.domain = args.scope
+    await deps.storage.updateGoldenRule(args.id, updates)
+    return JSON.stringify({ id: args.id, status: "updated", type: "golden_rule" })
+  }
+
+  return JSON.stringify({ error: `Memory item not found: ${args.id}`, status: "not_found" })
 }
 
 async function handleMetrics(deps: ElfToolDeps): Promise<string> {

--- a/src/tools/elf/tool.ts
+++ b/src/tools/elf/tool.ts
@@ -9,6 +9,8 @@ function mapToLearningType(input: string): LearningType {
   if (input === "success" || input === "failure" || input === "observation") return input
   return "observation"
 }
+const VALID_MEMORY_TYPES = ["golden_rule", "learning"] as const
+
 
 export interface ElfToolDeps {
   storage: IMemoryStorage
@@ -52,7 +54,7 @@ export function createElfTool(deps: ElfToolDeps) {
       type: tool.schema.string().optional().describe("Memory type filter or entry type"),
       scope: tool.schema.string().optional().describe("project or global scope"),
       limit: tool.schema.number().optional().describe("Max results for search"),
-      content: tool.schema.string().optional().describe("Content for add-rule action"),
+      content: tool.schema.string().optional().describe("Content for add-rule and update-rule actions"),
       id: tool.schema.string().optional().describe("Memory item ID for delete/update operations"),
     },
     async execute(args: ElfToolArgs) {
@@ -177,6 +179,10 @@ async function handleDeleteRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<s
     return JSON.stringify({ error: "id is required for delete-rule action" })
   }
 
+  if (args.type && !VALID_MEMORY_TYPES.includes(args.type as typeof VALID_MEMORY_TYPES[number])) {
+    return JSON.stringify({ error: `Unsupported type: ${args.type}. Valid types: ${VALID_MEMORY_TYPES.join(", ")}`, status: "error" })
+  }
+
   if (args.type === "golden_rule") {
     const existing = await deps.storage.getGoldenRule(args.id)
     if (!existing) {
@@ -217,6 +223,10 @@ async function handleUpdateRule(deps: ElfToolDeps, args: ElfToolArgs): Promise<s
   }
   if (!args.content) {
     return JSON.stringify({ error: "content is required for update-rule action" })
+  }
+
+  if (args.type && !VALID_MEMORY_TYPES.includes(args.type as typeof VALID_MEMORY_TYPES[number])) {
+    return JSON.stringify({ error: `Unsupported type: ${args.type}. Valid types: ${VALID_MEMORY_TYPES.join(", ")}`, status: "error" })
   }
 
   const filtered = deps.filterContent(args.content, PRIVACY_TAGS)


### PR DESCRIPTION
## Summary

Implements #12 — adds `delete-rule` and `update-rule` actions to the ELF memory tool, enabling agents to mutate existing memory items instead of only appending new ones.

## Changes

### Storage layer
- Added `getGoldenRule(id)` and `updateGoldenRule(id, updates)` to `IMemoryStorage` interface
- Implemented both in `memory-storage.ts` with FTS5 rebuild pattern (avoids `SQLITE_CORRUPT_VTAB`)
- Added missing `times_violated` column to `golden_rules` table schema

### ELF tool
- **`delete-rule`**: Removes a memory item by ID. Accepts optional `type` param; auto-detects (learning → golden_rule) when omitted
- **`update-rule`**: Updates content/scope of a memory item by ID. Applies privacy filtering and memory dump rejection. Auto-detects type when omitted
- Updated tool description and schema to expose `id` parameter and list all 5 actions

### Tests
- 14 new ELF tool tests (5 delete-rule + 9 update-rule) covering happy paths, error cases, auto-detection, privacy filtering, and memory dump rejection
- 5 new storage tests for `getGoldenRule` and `updateGoldenRule`
- Updated 8 mock implementations across 6 test files for the new `IMemoryStorage` methods

## Verification

- `bun run typecheck` — clean
- 140/140 tests pass across all 9 modified test files
- Zero LSP diagnostics on all implementation files

Closes #12